### PR TITLE
MGDAPI-1037 Add RBAC markers

### DIFF
--- a/config/crd/bases/integreatly.org_rhmis.yaml
+++ b/config/crd/bases/integreatly.org_rhmis.yaml
@@ -36,6 +36,8 @@ spec:
         spec:
           description: RHMISpec defines the desired state of RHMI
           properties:
+            alertFromAddress:
+              type: string
             alertingEmailAddress:
               type: string
             alertingEmailAddresses:
@@ -81,6 +83,8 @@ spec:
               - name
               - namespace
               type: object
+            rebalancePods:
+              type: boolean
             routingSubdomain:
               type: string
             selfSignedCerts:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,553 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resourceNames:
+  - grafana-datasources
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resourceNames:
+  - pull-secret
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - project.openshift.io
+  resources:
+  - projectrequests
+  verbs:
+  - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - applicationmonitoring.integreatly.org
+  - integreatly.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consolelinks
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - integreatly.org
+  resources:
+  - rhmiconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - rhmiconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - integreatly.org
+  resources:
+  - rhmis
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - rhmis/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - marin3r.3scale.net
+  resources:
+  - envoyconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - operator.marin3r.3scale.net
+  resources:
+  - discoveryservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resourceNames:
+  - rhmi-registry-cs
+  resources:
+  - catalogsources
+  verbs:
+  - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  - operatorgroups
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups:
+  - samples.operator.openshift.io
+  resourceNames:
+  - cluster
+  resources:
+  - configs
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - templates
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - user.openshift.io
+  resourceNames:
+  - rhmi-developers
+  resources:
+  - groups
+  verbs:
+  - delete
+  - update
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - identities
+  verbs:
+  - get
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - users
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: redhat-rhmi-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - pods
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - subscriptions/status
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: redhat-rhoam-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - pods
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - marin3r.3scale.net
+  resources:
+  - envoyconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - operator.marin3r.3scale.net
+  resources:
+  - discoveryservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - subscriptions/status
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/namespacelabel/namespacelabel_controller.go
+++ b/controllers/namespacelabel/namespacelabel_controller.go
@@ -161,8 +161,7 @@ type NamespaceLabelReconciler struct {
 	controller        controller.Controller
 }
 
-// +kubebuilder:rbac:resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:resources=namespaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;get;watch;update
 
 // Reconcile : The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.

--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -116,8 +116,14 @@ type SubscriptionReconciler struct {
 	csvLocator          csvlocator.CSVLocator
 }
 
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch;update;patch;delete
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions;subscriptions/status,verbs=get;list;watch;update;patch;delete,namespace=redhat-rhmi-operator
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions;subscriptions/status,verbs=get;list;watch;update;patch;delete,namespace=redhat-rhoam-operator
+
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=get;list;watch;update;patch;delete,namespace=redhat-rhmi-operator
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=get;list;watch;update;patch;delete,namespace=redhat-rhoam-operator
+
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list,namespace=redhat-rhmi-operator
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list,namespace=redhat-rhoam-operator
 
 // Reconcile will ensure that that Subscription object(s) have Manual approval for the upgrades
 // In a namespaced installation of integreatly operator it will only reconcile Subscription of the integreatly operator itself

--- a/controllers/user/user_controller.go
+++ b/controllers/user/user_controller.go
@@ -20,8 +20,9 @@ type UserReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=user.openshift.io,resources=users,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=user.openshift.io,resources=users/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=user.openshift.io,resources=groups,resourceNames=rhmi-developers,verbs=update;delete
+// +kubebuilder:rbac:groups=user.openshift.io,resources=users,verbs=watch;get;list
 
 func (r *UserReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-1037

`operator-sdk` uses now RBAC markers to generate the operator `Role` and `ClusterRole` . This change adds the markers to the controllers which generate the correct permissions for the operator

> Information about RBAC markers: https://book.kubebuilder.io/reference/markers/rbac.html

## Notes

## 1. `Role` generation

By default RBAC markers generate `ClusterRoles`, in order to generate a `Role`, a namespace must be specified in the marker. As the operator currently supports dynamic namespaces (either `redhat-rhmi-operator` or `redhat-rhoam-operator`), the markers are currently duplicated, so two `Roles` are generated in the different namespaces

# Verification steps

1. Clone the repo from this PR
2. Run `make manifests`
    > The command will currently fail, but the RBAC will be generated
3. Verify that the permissions listed in `config/rbac/role.yaml` match the permissions existing in [master](https://github.com/integr8ly/integreatly-operator/blob/master/deploy/role.yaml) (considering note 1)