### PR TITLE
Migrates the e2e tests to use testenv and GinkGo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/3scale/marin3r v0.6.0
 	github.com/Apicurio/apicurio-registry-operator v0.0.0-20200903111206-f9f14054bc16
 	github.com/Masterminds/semver v1.5.0
+	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/RHsyseng/operator-utils v0.0.0-20200709142328-d5a5812a443f
 	github.com/aerogear/unifiedpush-operator v0.5.0
 	github.com/apicurio/apicurio-operators/apicurito v0.0.0-20200123142409-83e0a91dd6be
@@ -20,12 +21,16 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/spec v0.19.12
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-querystring v1.0.0
 	github.com/googleapis/gnostic v0.5.3 // indirect
+	github.com/headzoo/surf v1.0.0
+	github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca // indirect
 	github.com/integr8ly/application-monitoring-operator v1.4.0
 	github.com/integr8ly/cloud-resource-operator v0.23.1-0.20210118104111-b5c5799f313c
 	github.com/integr8ly/grafana-operator v2.0.0+incompatible
 	github.com/integr8ly/grafana-operator/v3 v3.6.0
 	github.com/integr8ly/keycloak-client v0.1.3
+	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/keycloak/keycloak-operator v0.0.0-20210115090828-e5d4686bb8a4
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
@@ -39,6 +44,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/syndesisio/syndesis/install/operator v0.0.0-20201210151747-8264b9904eab
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
+github.com/PuerkitoBio/goquery v1.6.1 h1:FgjbQZKl5HTmcn4sKBgvx8vv63nhyhIpv7lJpFGCWpk=
+github.com/PuerkitoBio/goquery v1.6.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -152,6 +154,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
@@ -305,6 +309,7 @@ github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 h1:FwssHbCDJD025h+BchanCwE1Q8fyMgqDr2mOQAWOLGw=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -590,6 +595,7 @@ github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b/go.mod
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-licenses v0.0.0-20191112164736-212ea350c932/go.mod h1:16wa6pRqNDUIhOtwF0GcROVqMeXHZJ7H6eGDFUh5Pfk=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -739,6 +745,8 @@ github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4/go
 github.com/integr8ly/grafana-operator/v3 v3.5.0/go.mod h1:nie1yDLaWkgUjW+EBTLUjDzj1xsGOG444ZpcR1i1MrA=
 github.com/integr8ly/grafana-operator/v3 v3.6.0 h1:0+wUyPBT37kCM/2+sItKS3iEyeK1k+BnOJQOkES6vFI=
 github.com/integr8ly/grafana-operator/v3 v3.6.0/go.mod h1:pWWg9RerCkkwmTcmaygmfhkjjGilEN30han1yq2MAsA=
+github.com/integr8ly/keycloak-client v0.1.3 h1:fRF/M4XzDtLljzDIahD41MDPyAAJo1gD8JqVTYoz2oU=
+github.com/integr8ly/keycloak-client v0.1.3/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
@@ -771,6 +779,7 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsonnet-bundler/jsonnet-bundler v0.2.0/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K8mysFmDaM/h+o=
 github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
@@ -1419,6 +1428,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1887,6 +1897,7 @@ k8s.io/kube-aggregator v0.19.4 h1:ME+z/JfCTj7IzSWzu7XVhjWHxpEGGQ3gp2FpeOS+lW0=
 k8s.io/kube-aggregator v0.19.4/go.mod h1:cTkvun110194d797AuThyydBBlgm+cKIFUeS2uzGJfU=
 k8s.io/kube-openapi v0.0.0-20210113000636-45edf8a2a574 h1:YJES0QZiJJ5Vk4cx+ueDR6EYxhaD0xm5VBhXTaYayKc=
 k8s.io/kube-openapi v0.0.0-20210113000636-45edf8a2a574/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
+k8s.io/kubectl v0.19.4 h1:XFrHibf5fS4Ot8h3EnzdVsKrYj+pndlzKbwPkfra5hI=
 k8s.io/kubectl v0.19.4/go.mod h1:XPmlu4DJEYgD83pvZFeKF8+MSvGnYGqunbFSrJsqHv0=
 k8s.io/legacy-cloud-providers v0.17.0/go.mod h1:DdzaepJ3RtRy+e5YhNtrCYwlgyK87j/5+Yfp0L9Syp8=
 k8s.io/metrics v0.19.4/go.mod h1:a0gvAzrxQPw2ouBqnXI7X9qlggpPkKAFgWU/Py+KZiU=

--- a/test/common/3Scale_user_promotion.go
+++ b/test/common/3Scale_user_promotion.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func Test3ScaleUserPromotion(t TestingTB, ctx *TestingContext) {
+	var (
+		developerUser      = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+		dedicatedAdminUser = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+	)
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Get the 3Scale host url from the rhmi status
+	host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
+	if host == "" {
+		host = fmt.Sprintf("https://3scale-admin.%v", rhmi.Spec.RoutingSubdomain)
+	}
+
+	keycloakHost := rhmi.Status.Stages[rhmiv1alpha1.AuthenticationStage].Products[rhmiv1alpha1.ProductRHSSO].Host
+
+	if keycloakHost == "" {
+		t.Fatalf("Failed to retrieve keycloak host from RHMI CR: %v", rhmi)
+	}
+
+	redirectUrl := fmt.Sprintf("%v/p/admin/dashboard", host)
+
+	loginTo3ScaleAsDeveloper(t, developerUser, host, ctx)
+
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = loginToThreeScale(t, host, dedicatedAdminUser, DefaultPassword, TestingIDPRealm, httpClient)
+	if err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
+	}
+
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, httpClient, ctx.Client, t)
+
+	// Make sure 3Scale is available
+	err = tsClient.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userId, err := tsClient.GetUserId(developerUser)
+	if err != nil || userId == "" {
+		t.Fatal("Failed to retrieve user id for ", developerUser, "userId: ", userId, err)
+	}
+
+	err = tsClient.SetUserAsAdmin(developerUser, fmt.Sprintf("%v@example.com", developerUser), userId)
+	if err != nil {
+		t.Fatal("Failed to set user as admin ", err)
+	}
+
+	// TODO: Waiting an arbitrary amount of time to verify that a 3Scale reconcile was complete
+	// and did not result in reverting the promotion of test-user to admin
+	// Change this when https://issues.redhat.com/browse/INTLY-7770 implemented
+	_ = wait.Poll(time.Second*350, time.Minute*7, func() (done bool, err error) {
+
+		isAdmin, err := tsClient.VerifyUserIsAdmin(userId)
+		if err != nil {
+			t.Fatal("Error attempting to verify that the user is an admin ", err)
+		}
+		if !isAdmin {
+			t.Fatal("User reverted from admin back to member")
+		}
+
+		return true, nil
+	})
+
+}
+
+// Login as a developer and create a separate HTTP client. This will mimic what would happen in reality
+// i.e. 2 users using separate browsers.
+func loginTo3ScaleAsDeveloper(t TestingTB, user string, host string, ctx *TestingContext) {
+
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = loginToThreeScale(t, host, user, DefaultPassword, TestingIDPRealm, httpClient)
+	if err != nil {
+		t.Fatalf("Failed to log into 3Scale: %v", err)
+	}
+}

--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+)
+
+var (
+	threescaleLoginUser = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+)
+
+// Tests that a user in group rhmi-developers can log into fuse and
+// create an integration
+func Test3ScaleCrudlPermissions(t TestingTB, ctx *TestingContext) {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Get the fuse host url from the rhmi status
+	host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
+	if host == "" {
+		host = fmt.Sprintf("https://3scale-admin.%v", rhmi.Spec.RoutingSubdomain)
+	}
+	keycloakHost := rhmi.Status.Stages[rhmiv1alpha1.AuthenticationStage].Products[rhmiv1alpha1.ProductRHSSO].Host
+	redirectUrl := fmt.Sprintf("%v/p/admin/dashboard", host)
+
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, ctx.HttpClient, ctx.Client, t)
+
+	// Login to 3Scale
+	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
+	if err != nil {
+		// t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+	}
+
+	// Make sure 3Scale is available
+	err = tsClient.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+
+	// Create a product
+	productId, err := tsClient.CreateProduct(fmt.Sprintf("dummy-product-%v", r1.Intn(100000)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the product
+	err = tsClient.DeleteProduct(productId)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -1,0 +1,420 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+
+	k8sv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testNamespace = "smtp-server"
+)
+
+var (
+	s1                            = rand.NewSource(time.Now().UnixNano())
+	r1                            = rand.New(s1)
+	smtpReplicas            int32 = 1
+	threescaleLoginUserSMTP       = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+	emailAddress                  = fmt.Sprintf("test%v@test.com", r1.Intn(200))
+	serviceIP                     = ""
+	emailUsername                 = "dummy"
+	emailPassword                 = "dummy"
+	emailPort                     = "1587"
+	originalHost                  = ""
+	originalPassword              = ""
+	originalPort                  = ""
+	originalUsername              = ""
+)
+
+//Test3ScaleSMTPConfig to confirm 3scale can send an email
+func Test3ScaleSMTPConfig(t TestingTB, ctx *TestingContext) {
+	inst, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI instance %v", err)
+	}
+
+	t.Log("Create Namespace, Deployment and Service for SMTP-Server")
+	err = createNamespace(ctx, t)
+	if err != nil {
+		t.Logf("%v", err)
+	}
+
+	_, err = patchSecret(ctx, t)
+	if err != nil {
+		t.Log(err)
+	}
+
+	t.Log("Wait for reconciliation of SMTP details")
+	err = checkSMTPReconciliation(ctx, t)
+	if err != nil {
+		t.Fatalf("Unable to reconcile smtp details : %v ", err)
+	}
+
+	// Scale down system-app and system-sidekiq in order to load new smtp config
+	for _, dc := range []string{"system-app", "system-sidekiq"} {
+		t.Logf("Scalind down dc '%s' to 0 replicas in '%s' namespace", dc, threescaleNamespace)
+		err = scaleDeploymentConfig(dc, threescaleNamespace, 0, ctx.Client)
+		if err != nil {
+			t.Errorf("Failed to scale down %s: %v ", dc, err)
+		}
+	}
+
+	t.Log("Checking pods are ready")
+	threescaleConfig := config.NewThreeScale(map[string]string{})
+	replicas := threescaleConfig.GetReplicasConfig(inst)
+	if err := check3ScaleReplicasAreReady(ctx, t, replicas, retryInterval, timeout); err != nil {
+		t.Logf("Replicas not Ready within timeout: %v", err)
+	}
+
+	// Add sleep to give threescale time to reconcile the pods restarts otherwise host address will update during next steps
+	time.Sleep(30 * time.Second)
+	t.Log("Checking host address is ready")
+	err = checkHostAddressIsReady(ctx, t, retryInterval, timeout)
+	if err != nil {
+		t.Log(err)
+	}
+
+	t.Log("Send Test email")
+	sendTestEmail(ctx, t)
+
+	t.Log("confirm email received")
+	err = checkEmail(ctx, t, emailAddress)
+	if err != nil {
+		t.Fatal("No email found")
+	}
+
+	t.Log("Reset email details")
+	_, err = resetSecret(ctx, t)
+	if err != nil {
+		t.Log(err)
+	}
+
+	t.Log("Removing smtp-server namespace")
+	err = removeNamespace(ctx)
+	if err != nil {
+		t.Log(err)
+	}
+
+}
+
+func checkHostAddressIsReady(ctx *TestingContext, t TestingTB, retryInterval, timeout time.Duration) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+
+		// get console master url
+		rhmi, err := GetRHMI(ctx.Client, true)
+		if err != nil {
+			t.Fatalf("error getting RHMI CR: %v", err)
+		}
+
+		host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
+		status := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Status
+		if host == "" || status == "in progress" {
+			t.Log("3scale host URL not ready yet.")
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		//return fmt.Error("Number of replicas for threescale replicas is not correct : Replicas - %w, Expected")
+		return fmt.Errorf("Error, Host url not ready before timeout - %v", err)
+	}
+	return nil
+
+}
+
+func removeNamespace(ctx *TestingContext) error {
+	//Remove the smtp-server namespace to clean up after test
+	nameSpaceForDeletion := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "smtp-server",
+			Namespace: "smtp-server",
+		},
+	}
+
+	err := ctx.Client.Delete(goctx.TODO(), nameSpaceForDeletion)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkSMTPReconciliation(ctx *TestingContext, t TestingTB) error {
+	//Check that the smtp details have reconciled to the 3scale secret
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		threescaleSecret, err := get3scaleSecret(ctx)
+		if err != nil {
+			t.Fatalf("Failed to get threescale secret %v", err)
+		}
+
+		rhmiSecret, err := getSecret(ctx)
+		if err != nil {
+			t.Fatalf("Failed to get rhmi secret %v", err)
+		}
+
+		if string(threescaleSecret.Data["address"]) != string(rhmiSecret.Data["host"]) {
+			return false, nil
+		}
+		if string(threescaleSecret.Data["password"]) != string(rhmiSecret.Data["password"]) {
+			return false, nil
+		}
+		if string(threescaleSecret.Data["port"]) != string(rhmiSecret.Data["port"]) {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func checkEmail(ctx *TestingContext, t TestingTB, email string) error {
+	//Check that we have received the test email
+	receivedEmail := false
+	pods, err := ctx.KubeClient.CoreV1().Pods("smtp-server").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Logf("Couldn't find pods: %v", err)
+	}
+	for _, pod := range pods.Items {
+		fmt.Println(pod.Name, pod.Status.PodIP)
+		// exec into the smtp-server pod
+		output, err := execToPod("cat /newuser/mail.log",
+			pod.Name,
+			"smtp-server",
+			"smtp-server", ctx)
+		if err != nil {
+			t.Fatal("failed to exec to pod:", err)
+		}
+		t.Log(output)
+		needle := "To: " + email
+		if strings.Contains(output, needle) {
+			receivedEmail = true
+		}
+
+	}
+	if receivedEmail == false {
+		return err
+	}
+	return nil
+}
+
+func sendTestEmail(ctx *TestingContext, t TestingTB) {
+	// Send test email using the 3scale api
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Get the fuse host url from the rhmi status
+	host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
+	if host == "" {
+		host = fmt.Sprintf("https://3scale-admin.%v", rhmi.Spec.RoutingSubdomain)
+	}
+	keycloakHost := rhmi.Status.Stages[rhmiv1alpha1.AuthenticationStage].Products[rhmiv1alpha1.ProductRHSSO].Host
+	redirectURL := fmt.Sprintf("%v/p/admin/dashboard", host)
+
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectURL, ctx.HttpClient, ctx.Client, t)
+
+	// Login to 3Scale
+	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
+	if err != nil {
+		// t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+	}
+
+	// Make sure 3Scale is available
+	err = tsClient.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Sending email")
+	_, err = tsClient.SendUserInvitation(emailAddress)
+	if err != nil {
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+	}
+}
+
+func resetSecret(ctx *TestingContext, t TestingTB) (string, error) {
+	//Reset the smtp details back to the pre test version
+	secret, err := getSecret(ctx)
+
+	if err != nil {
+		return "", err
+	}
+
+	secret = v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NamespacePrefix + "smtp",
+			Namespace: NamespacePrefix + "operator",
+		},
+		Data: map[string][]byte{},
+	}
+	secret.Data["host"] = []byte(originalHost)
+	secret.Data["password"] = []byte(originalPassword)
+	secret.Data["port"] = []byte(originalPort)
+	secret.Data["username"] = []byte(originalUsername)
+
+	if err := ctx.Client.Update(goctx.TODO(), secret.DeepCopy(), &k8sclient.UpdateOptions{}); err != nil {
+		return secret.APIVersion, err
+	}
+
+	return "", nil
+}
+
+func patchSecret(ctx *TestingContext, t TestingTB) (string, error) {
+	// Update secret with our test smtp details
+	serviceIP, err := getServiceIP(ctx)
+
+	secret, err := getSecret(ctx)
+
+	if err != nil {
+		return "", err
+	}
+	originalHost = string(secret.Data["host"])
+	originalPassword = string(secret.Data["password"])
+	originalPort = string(secret.Data["port"])
+	originalUsername = string(secret.Data["username"])
+
+	secret = v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NamespacePrefix + "smtp",
+			Namespace: NamespacePrefix + "operator",
+		},
+		Data: map[string][]byte{},
+	}
+
+	secret.Data["host"] = []byte(serviceIP)
+	secret.Data["password"] = []byte(emailPassword)
+	secret.Data["port"] = []byte(emailPort)
+	secret.Data["username"] = []byte(emailUsername)
+
+	if err := ctx.Client.Update(goctx.TODO(), secret.DeepCopy(), &k8sclient.UpdateOptions{}); err != nil {
+		return secret.APIVersion, err
+	}
+
+	return "", nil
+}
+
+func getSecret(ctx *TestingContext) (v1.Secret, error) {
+
+	secret := &v1.Secret{}
+	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: NamespacePrefix + "smtp", Namespace: NamespacePrefix + "operator"}, secret); err != nil {
+		return *secret, err
+	}
+	return *secret, nil
+}
+
+func get3scaleSecret(ctx *TestingContext) (v1.Secret, error) {
+
+	secret := &v1.Secret{}
+	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: "system-smtp", Namespace: NamespacePrefix + "3scale"}, secret); err != nil {
+		return *secret, err
+	}
+	return *secret, nil
+}
+
+func getServiceIP(ctx *TestingContext) (string, error) {
+	service := &v1.Service{}
+
+	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: "smtp-server", Namespace: "smtp-server"}, service); err != nil {
+		return service.Spec.ClusterIP, err
+	}
+
+	return service.Spec.ClusterIP, nil
+}
+
+func createNamespace(ctx *TestingContext, t TestingTB) error {
+
+	// Create namespace for our test smtp-server
+	t.Log("Creating namespace, deployment and service")
+	nsSpec := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+
+	_, err := ctx.KubeClient.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("Unable to create namespace : %v", err)
+	}
+
+	// Create deployement for smtp-server
+	deployment := &k8sv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "smtp-server",
+		},
+		Spec: k8sv1.DeploymentSpec{
+			Replicas: &smtpReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "smtp-server",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "smtp-server",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "smtp-server",
+							Image: "quay.io/cathaloconnor/smtp-server:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "tcp",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: 1587,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = ctx.KubeClient.AppsV1().Deployments(testNamespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("Unable to create deployment : %v", err)
+	}
+
+	// Create service for smtp-server
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "smtp-server",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Port:       int32(1587),
+				TargetPort: intstr.FromInt(1587),
+				Protocol:   v1.ProtocolTCP,
+			}},
+			Selector: map[string]string{
+				"app": "smtp-server",
+			},
+		},
+	}
+
+	_, err = ctx.KubeClient.CoreV1().Services(testNamespace).Create(context.TODO(), &service, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("Unable to create service : %v", err)
+	}
+	return nil
+}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -1,0 +1,1068 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type alertsTestRule struct {
+	File  string   `json:"file"`
+	Rules []string `json:"rules"`
+}
+
+type alertsTestReport struct {
+	MissingRules    []string             `json:"missing"`
+	AdditionalRules []string             `json:"additional"`
+	Status          alertsTestFileStatus `json:"status"`
+}
+
+func newDefaultReport(status alertsTestFileStatus) *alertsTestReport {
+	return &alertsTestReport{
+		MissingRules:    []string{},
+		AdditionalRules: []string{},
+		Status:          status,
+	}
+}
+
+type alertsTestFileStatus string
+
+var (
+	fileMissing    alertsTestFileStatus = "File expected but not found"
+	fileAdditional alertsTestFileStatus = "File found but not expected"
+	fileExists     alertsTestFileStatus = "File found with missing or unexpected rules"
+	fileCorrect    alertsTestFileStatus = "File found with all alerts present"
+)
+
+// Specific to RHMI2
+func rhmi2ExpectedRules() []alertsTestRule {
+
+	return []alertsTestRule{
+		{
+			File: NamespacePrefix + "amq-online-backupjobs-exist-alerts.yaml",
+			Rules: []string{
+				"CronJobExists_" + NamespacePrefix + "amq-online_enmasse-pv-backup",
+				"CronJobExists_" + NamespacePrefix + "amq-online_enmasse-postgres-backup",
+				"CronJobExists_" + NamespacePrefix + "amq-online_resources-backup",
+			},
+		},
+		{
+			File: NamespacePrefix + "codeready-workspaces-backupjobs-exist-alerts.yaml",
+			Rules: []string{
+				"CronJobExists_" + NamespacePrefix + "codeready-workspaces_codeready-pv-backup",
+			},
+		},
+		{
+			File: NamespacePrefix + "amq-online-ksm-amqonline-alerts.yaml",
+			Rules: []string{
+				"AMQOnlinePodCount",
+				"AMQOnlineContainerHighMemory",
+			},
+		},
+		{
+			File: NamespacePrefix + "apicurito-ksm-apicurito-alerts.yaml",
+			Rules: []string{
+				"ApicuritoPodCount",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-ksm-fuse-online-alerts.yaml",
+			Rules: []string{
+				"FuseOnlineSyndesisServerInstanceDown",
+				"FuseOnlineSyndesisUIInstanceDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "codeready-workspaces-ksm-codeready-alerts.yaml",
+			Rules: []string{
+				"CodeReadyPodCount",
+			},
+		},
+		{
+			File: NamespacePrefix + "amq-online-rhmi-amq-online-slo.yaml",
+			Rules: []string{
+				"AMQOnlineConsoleAvailable",
+				"AMQOnlineKeycloakAvailable",
+				"AMQOnlineOperatorAvailable",
+			},
+		},
+		{
+			File: NamespacePrefix + "solution-explorer-ksm-solution-explorer-alerts.yaml",
+			Rules: []string{
+				"SolutionExplorerPodCount",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-syndesis-infra-meta-alerting-rules.yaml",
+			Rules: []string{
+				"FuseOnlineRestApiHighEndpointErrorRate",
+				"FuseOnlineRestApiHighEndpointLatency",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-syndesis-infra-server-alerting-rules.yaml",
+			Rules: []string{
+				"FuseOnlineRestApiHighEndpointErrorRate",
+				"FuseOnlineRestApiHighEndpointLatency",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-syndesis-integrations-alerting-rules.yaml",
+			Rules: []string{
+				"IntegrationExchangesHighFailureRate",
+			},
+		},
+		{
+			File: NamespacePrefix + "ups-unifiedpush.yaml",
+			Rules: []string{
+				"UnifiedPushDown",
+				"UnifiedPushConsoleDown",
+				"UnifiedPushJavaHeapThresholdExceeded",
+				"UnifiedPushJavaNonHeapThresholdExceeded",
+				"UnifiedPushJavaGCTimePerMinuteScavenge",
+				"UnifiedPushJavaDeadlockedThreads",
+				"UnifiedPushMessagesFailures",
+			},
+		},
+		{
+			File: NamespacePrefix + "ups-operator-unifiedpush-operator.yaml",
+			Rules: []string{
+				"UnifiedPushOperatorDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "amq-online-kube-metrics.yaml",
+			Rules: []string{
+				"TerminatingPods",
+				"RestartingPods",
+				"RestartingPods",
+				"PendingPods",
+			},
+		},
+		{
+			File: NamespacePrefix + "amq-online-enmasse.yaml",
+			Rules: []string{
+				"ComponentHealth",
+				"AuthenticationService",
+				"AddressSpaceHealth",
+				"AddressHealth",
+				"RouterMeshConnectivityHealth",
+				"RouterMeshUndeliveredHealth",
+				"BrokerMemory",
+			},
+		},
+		{
+			File:  NamespacePrefix + "amq-online-enmasse-console-rules.yaml",
+			Rules: []string{},
+		},
+		{
+			File: NamespacePrefix + "apicurito-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIApicuritoServiceEndpointDown",
+				"RHMIApicuritoFuseApicuritoGeneratorServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "amq-online-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIAMQOnlineNoneAuthServiceEndpointDown",
+				"RHMIAMQOnlineAddressSpaceControllerServiceEndpointDown",
+				"RHMIAMQOnlineConsoleServiceEndpointDown",
+				"RHMIAMQOnlineRegistryCsServiceEndpointDown",
+				"RHMIAMQOnlineStandardAuthServiceEndpointDown",
+				"RHMIAMQOnlineEnmasseOperatorMetricsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIFuseOnlineOperatorRhmiRegistryCsServiceEndpointDown",
+				"RHMIFuseOnlineOperatorSyndesisOperatorMetricsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "ups-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIUPSOperatorRhmiRegistryCsServiceEndpointDown",
+				"RHMIUPSOperatorUnifiedPushOperatorMetricsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "codeready-workspaces-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMICodeReadyCheHostServiceEndpointDown",
+				"RHMICodeReadyDevfileRegistryServiceEndpointDown",
+				"RHMICodeReadyPluginRegistryServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "apicurito-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIApicuritoOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "solution-explorer-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMISolutionExplorerTutorialWebAppServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "solution-explorer-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMISolutionExplorerOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "codeready-workspaces-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMICodeReadyOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "fuse-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIFuseOnlineBrokerAmqTcpServiceEndpointDown",
+				"RHMIFuseOnlineSyndesisMetaServiceEndpointDown",
+				"RHMIFuseOnlineSyndesisOauthproxyServiceEndpointDown",
+				"RHMIFuseOnlineSyndesisPrometheusServiceEndpointDown",
+				"RHMIFuseOnlineSyndesisServerServiceEndpointDown",
+				"RHMIFuseOnlineSyndesisUiServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "ups-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIUPSUnifiedPushServiceEndpointDown",
+				"RHMIUPSUnifiedpushProxyServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-rhmi-installation-controller-alerts.yaml",
+			Rules: []string{
+				"RHMIInstallationControllerIsNotReconciling",
+				"RHMIInstallationControllerStoppedReconciling",
+			},
+		},
+	}
+}
+
+// Managed-Api-Service rules
+func managedApiSpecificRules() []alertsTestRule {
+
+	return []alertsTestRule{
+		{
+			File: NamespacePrefix + "marin3r-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"Marin3rDiscoveryServiceEndpointDown",
+				"Marin3rPromstatsdExporterServiceEndpointDown",
+				"Marin3rRateLimitServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"Marin3rOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-operator-ksm-marin3r-alerts.yaml",
+			Rules: []string{
+				"Marin3rOperatorPod",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-ksm-marin3r-alerts.yaml",
+			Rules: []string{
+				"Marin3rDiscoveryServicePod",
+				"Marin3rPromstatsdExporterPod",
+				"Marin3rRateLimitPod",
+			},
+		},
+		{
+			File: NamespacePrefix + "3scale-ksm-marin3r-alerts.yaml",
+			Rules: []string{
+				"Marin3rEnvoyApicastStagingContainerDown",
+				"Marin3rEnvoyApicastProductionContainerDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "customer-monitoring-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"GrafanaOperatorRhmiRegistryCsServiceEndpointDown",
+				"GrafanaServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "customer-monitoring-operator-ksm-grafana-alerts.yaml",
+			Rules: []string{
+				"GrafanaOperatorPod",
+				"GrafanaServicePod",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-api-usage-alert-level1.yaml",
+			Rules: []string{
+				"RHOAMApiUsageLevel1ThresholdExceeded",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-api-usage-alert-level2.yaml",
+			Rules: []string{
+				"RHOAMApiUsageLevel2ThresholdExceeded",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-api-usage-alert-level3.yaml",
+			Rules: []string{
+				"RHOAMApiUsageLevel3ThresholdExceeded",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-rate-limit-soft-limits.yaml",
+			Rules: []string{
+				"RHOAMApiUsageSoftLimitReachedTier1",
+				"RHOAMApiUsageSoftLimitReachedTier2",
+				"RHOAMApiUsageSoftLimitReachedTier3",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-rate-limit-spike.yaml",
+			Rules: []string{
+				"RHOAMApiUsageOverLimit",
+			},
+		},
+		{
+			File: NamespacePrefix + "marin3r-rejected-requests.yaml",
+			Rules: []string{
+				"RHOAMApiUsageRejectedRequestsMismatch",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-rhoam-installation-controller-alerts.yaml",
+			Rules: []string{
+				"RHOAMInstallationControllerIsNotReconciling",
+				"RHOAMInstallationControllerStoppedReconciling",
+			},
+		},
+	}
+}
+
+// Common to all install types
+func commonExpectedRules() []alertsTestRule {
+	return []alertsTestRule{
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-backup-monitoring-alerts.yaml",
+			Rules: []string{
+				"JobRunningTimeExceeded",
+				"JobRunningTimeExceeded",
+				"CronJobsFailed",
+				"CronJobNotRunInThreshold",
+			},
+		},
+		{
+			File: NamespacePrefix + "rhsso-keycloak.yaml",
+			Rules: []string{
+				"KeycloakJavaHeapThresholdExceeded",
+				"KeycloakJavaNonHeapThresholdExceeded",
+				"KeycloakJavaGCTimePerMinuteScavenge",
+				"KeycloakJavaGCTimePerMinuteMarkSweep",
+				"KeycloakJavaDeadlockedThreads",
+				"KeycloakLoginFailedThresholdExceeded",
+				"KeycloakInstanceNotAvailable",
+				"KeycloakAPIRequestDuration90PercThresholdExceeded",
+				"KeycloakAPIRequestDuration99.5PercThresholdExceeded",
+			},
+		},
+		{
+			File: NamespacePrefix + "user-sso-keycloak.yaml",
+			Rules: []string{
+				"KeycloakJavaHeapThresholdExceeded",
+				"KeycloakJavaNonHeapThresholdExceeded",
+				"KeycloakJavaGCTimePerMinuteScavenge",
+				"KeycloakJavaGCTimePerMinuteMarkSweep",
+				"KeycloakJavaDeadlockedThreads",
+				"KeycloakLoginFailedThresholdExceeded",
+				"KeycloakInstanceNotAvailable",
+				"KeycloakAPIRequestDuration90PercThresholdExceeded",
+				"KeycloakAPIRequestDuration99.5PercThresholdExceeded",
+			},
+		},
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-ksm-alerts.yaml",
+			Rules: []string{
+				"KubePodCrashLooping",
+				"KubePodNotReady",
+				"KubePodImagePullBackOff",
+				"KubePodBadConfig",
+				"KubePodStuckCreating",
+				"ClusterSchedulableMemoryLow",
+				"ClusterSchedulableCPULow",
+				"PVCStorageAvailable",
+				"PVCStorageMetricsAvailable",
+				"KubePersistentVolumeFillingUp",
+				"KubePersistentVolumeFillingUp",
+				"PersistentVolumeErrors",
+			},
+		},
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-ksm-monitoring-alerts.yaml",
+			Rules: []string{
+				"MiddlewareMonitoringPodCount",
+			},
+		},
+		{
+			File: NamespacePrefix + "3scale-ksm-3scale-alerts.yaml",
+			Rules: []string{
+				"ThreeScaleApicastStagingPod",
+				"ThreeScaleApicastProductionPod",
+				"ThreeScaleBackendWorkerPod",
+				"ThreeScaleBackendListenerPod",
+				"ThreeScaleSystemAppPod",
+				"ThreeScaleAdminUIBBT",
+				"ThreeScaleDeveloperUIBBT",
+				"ThreeScaleSystemAdminUIBBT",
+				"ThreeScaleContainerHighMemory",
+				"ThreeScaleContainerHighCPU",
+				"ThreeScaleZyncPodAvailability",
+				"ThreeScaleZyncDatabasePodAvailability",
+				"ThreescaleApicastWorkerRestart",
+			},
+		},
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-prometheus-application-monitoring-rules.yaml",
+			Rules: []string{
+				"DeadMansSwitch",
+			},
+		},
+		{
+			File: NamespacePrefix + "3scale-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIThreeScaleApicastProductionServiceEndpointDown",
+				"RHMIThreeScaleApicastStagingServiceEndpointDown",
+				"RHMIThreeScaleBackendListenerServiceEndpointDown",
+				"RHMIThreeScaleSystemDeveloperServiceEndpointDown",
+				"RHMIThreeScaleSystemMasterServiceEndpointDown",
+				"RHMIThreeScaleSystemMemcacheServiceEndpointDown",
+				"RHMIThreeScaleSystemProviderServiceEndpointDown",
+				"RHMIThreeScaleSystemSphinxServiceEndpointDown",
+				"RHMIThreeScaleZyncDatabaseServiceEndpointDown",
+				"RHMIThreeScaleZyncServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "user-sso-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIUserRhssoKeycloakServiceEndpointDown",
+				"RHMIUserRhssoKeycloakDiscoveryServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "cloud-resources-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMICloudResourceOperatorMetricsServiceEndpointDown",
+				"RHMICloudResourceOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIMiddlewareMonitoringOperatorAlertmanagerOperatedServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorAlertmanagerServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorApplicationMonitoringMetricsServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorGrafanaServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorPrometheusOperatedServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorPrometheusServiceEndpointDown",
+				"RHMIMiddlewareMonitoringOperatorRhmiRegistryCsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "rhsso-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIRhssoKeycloakServiceEndpointDown",
+				"RHMIRhssoKeycloakDiscoveryServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "rhsso-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIRhssoKeycloakOperatorRhmiRegistryCsServiceEndpointDown",
+				"RHMIRhssoKeycloakOperatorMetricsServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "3scale-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIThreeScaleOperatorRhmiRegistryCsServiceEndpointDown",
+				"RHMIThreeScaleOperatorServiceEndpointDown",
+			},
+		},
+		{
+			File: NamespacePrefix + "user-sso-operator-ksm-endpoint-alerts.yaml",
+			Rules: []string{
+				"RHMIUserRhssoOperatorRhmiRegistryCsMetricsServiceEndpointDown",
+				"RHMIUserRhssoKeycloakOperatorMetricsServiceEndpointDown",
+			},
+		},
+		{
+			File: MonitoringOperatorNamespace + "-install-upgrade-alerts.yaml",
+			Rules: []string{
+				"RHMICSVRequirementsNotMet",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-sendgrid-smtp-secret-exists-rule.yaml",
+			Rules: []string{
+				"SendgridSmtpSecretExists",
+			},
+		},
+		{
+			File: NamespacePrefix + "middleware-monitoring-operator-multi-az-pod-distribution.yaml",
+			Rules: []string{
+				"MultiAZPodDistribution",
+			},
+		},
+	}
+}
+
+// common aws rules applicable to all install types
+func commonExpectedAWSRules(installationName string) []alertsTestRule {
+	titledName := strings.Title(installationName)
+
+	return []alertsTestRule{
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-threescale-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Redis-%sRedisCacheConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-threescale-backend-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Backend-Redis-%sRedisCacheConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-threescale-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Postgres-%sPostgresConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-threescale-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Redis-%sRedisCacheUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-threescale-backend-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Backend-Redis-%sRedisCacheUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-threescale-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Redis-%sRedisResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-threescale-backend-redis-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Backend-Redis-%sRedisResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-threescale-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Postgres-%sPostgresResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-rhsso-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhsso-Postgres-%sPostgresResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-rhssouser-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhssouser-Postgres-%sPostgresResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-threescale-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Postgres-%sPostgresInstanceUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-rhssouser-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhssouser-Postgres-%sPostgresConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-rhssouser-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhssouser-Postgres-%sPostgresInstanceUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-rhsso-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhsso-Postgres-%sPostgresConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-rhsso-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhsso-Postgres-%sPostgresInstanceUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-threescale-redis-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Redis-%sRedisResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-rhssouser-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhssouser-Postgres-%sPostgresResourceStatusPhasePending", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-rhsso-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhsso-Postgres-%sPostgresResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-threescale-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Postgres-%sPostgresResourceStatusPhasePending", titledName),
+			},
+		},
+
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-threescale-redis-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Redis-%sRedisResourceStatusPhasePending", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-rhsso-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhsso-Postgres-%sPostgresResourceStatusPhasePending", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-threescale-backend-redis-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Backend-Redis-%sRedisResourceStatusPhasePending", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-rhssouser-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Rhssouser-Postgres-%sPostgresResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-threescale-backend-redis-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Backend-Redis-%sRedisResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-threescale-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				fmt.Sprintf("Threescale-Postgres-%sPostgresResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-postgres-storage-will-fill-in-4-hours.yaml",
+			Rules: []string{
+				"PostgresStorageWillFillIn4Hours",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-postgres-storage-will-fill-in-4-days.yaml",
+			Rules: []string{
+				"PostgresStorageWillFillIn4Days",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-postgres-storage-low.yaml",
+			Rules: []string{
+				"PostgresStorageLow",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-postgres-cpu-high.yaml",
+			Rules: []string{
+				"PostgresCPUHigh",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-postgres-freeable-memory-low.yaml",
+			Rules: []string{
+				"PostgresFreeableMemoryLow",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-redis-memory-usage-high.yaml",
+			Rules: []string{
+				"RedisMemoryUsageHigh",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-redis-memory-usage-will-max-in-4-hours.yaml",
+			Rules: []string{
+				"RedisMemoryUsageMaxIn4Hours",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-redis-memory-usage-max-fill-in-4-days.yaml",
+			Rules: []string{
+				"RedisMemoryUsageMaxIn4Days",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-redis-cpu-usage-high.yaml",
+			Rules: []string{
+				"RedisCpuUsageHigh",
+			},
+		},
+	}
+}
+
+// rhmi2 aws rules
+func rhmi2ExpectedAWSRules(installationName string) []alertsTestRule {
+	return []alertsTestRule{
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-codeready-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Codeready-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-ups-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Ups-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-resource-deletion-status-phase-failed-rule-fuse-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Fuse-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-ups-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Ups-Postgres-RhmiPostgresConnectionFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-ups-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Ups-Postgres-RhmiPostgresInstanceUnavailable",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-codeready-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Codeready-Postgres-RhmiPostgresInstanceUnavailable",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-codeready-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Codeready-Postgres-RhmiPostgresConnectionFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-connectivity-rule-fuse-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Fuse-Postgres-RhmiPostgresConnectionFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%s-availability-rule-fuse-postgres-%s.yaml", RHMIOperatorNamespace, installationName),
+			Rules: []string{
+				"Fuse-Postgres-RhmiPostgresInstanceUnavailable",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-fuse-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Fuse-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-ups-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Ups-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-ups-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Ups-Postgres-RhmiPostgresResourceStatusPhasePending",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-fuse-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Fuse-Postgres-RhmiPostgresResourceStatusPhasePending",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-codeready-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Codeready-Postgres-RhmiPostgresResourceStatusPhaseFailed",
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-codeready-postgres-%s.yaml", NamespacePrefix, installationName),
+			Rules: []string{
+				"Codeready-Postgres-RhmiPostgresResourceStatusPhasePending",
+			},
+		},
+	}
+}
+
+func managedApiAwsExpectedRules(installtionName string) []alertsTestRule {
+	titledName := strings.Title(installtionName)
+
+	return []alertsTestRule{
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-failed-rule-ratelimit-service-redis-%s.yaml", NamespacePrefix, installtionName),
+			Rules: []string{
+				fmt.Sprintf("Ratelimit-Service-Redis-%sRedisResourceStatusPhaseFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-status-phase-pending-rule-ratelimit-service-redis-%s.yaml", NamespacePrefix, installtionName),
+			Rules: []string{
+				fmt.Sprintf("Ratelimit-Service-Redis-%sRedisResourceStatusPhasePending", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-availability-rule-ratelimit-service-redis-%s.yaml", NamespacePrefix, installtionName),
+			Rules: []string{
+				fmt.Sprintf("Ratelimit-Service-Redis-%sRedisCacheUnavailable", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-connectivity-rule-ratelimit-service-redis-%s.yaml", NamespacePrefix, installtionName),
+			Rules: []string{
+				fmt.Sprintf("Ratelimit-Service-Redis-%sRedisCacheConnectionFailed", titledName),
+			},
+		},
+		{
+			File: fmt.Sprintf("%soperator-resource-deletion-status-phase-failed-rule-ratelimit-service-redis-%s.yaml", NamespacePrefix, installtionName),
+			Rules: []string{
+				fmt.Sprintf("Ratelimit-Service-Redis-%sRedisResourceDeletionStatusPhaseFailed", titledName),
+			},
+		},
+	}
+
+}
+
+func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
+	isClusterStorage, err := isClusterStorage(ctx)
+	if err != nil {
+		t.Fatal("error getting isClusterStorage:", err)
+	}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+	expectedAWSRules := getExpectedAWSRules(rhmi.Spec.Type, rhmi.Name)
+	expectedRules := getExpectedRules(rhmi.Spec.Type)
+
+	// add external database alerts to list of expected rules if
+	// cluster storage is not being used
+	if !isClusterStorage {
+		for _, rule := range expectedAWSRules {
+			expectedRules = append(expectedRules, rule)
+		}
+	}
+
+	// exec into the prometheus pod
+	output, err := execToPod("curl localhost:9090/api/v1/rules",
+		"prometheus-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to exec to pod:", err)
+	}
+
+	// get all found rules from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		t.Fatal("failed to unmarshal json:", err)
+	}
+	var rulesResult prometheusv1.RulesResult
+	err = json.Unmarshal([]byte(promApiCallOutput.Data), &rulesResult)
+	if err != nil {
+		t.Fatal("failed to unmarshal json:", err)
+	}
+
+	// convert prometheus rule to PrometheusRule type
+	var actualRules []alertsTestRule
+	for _, group := range rulesResult.Groups {
+		ruleName := strings.Split(group.File, "/")
+		rule := alertsTestRule{
+			File: ruleName[len(ruleName)-1],
+		}
+		for _, promRule := range group.Rules {
+			switch v := promRule.(type) {
+			case prometheusv1.RecordingRule:
+			case prometheusv1.AlertingRule:
+				alertRule := promRule.(prometheusv1.AlertingRule)
+				rule.Rules = append(rule.Rules, alertRule.Name)
+			default:
+				t.Logf("unknown rule type %s", v)
+			}
+		}
+		actualRules = append(actualRules, rule)
+	}
+
+	// build up a reportMapping of missing or unexpected files
+	reportMapping := make(map[string]*alertsTestReport, 0)
+
+	// unexpected/additional
+	// if an unexpected file is found, add it to the reportMapping
+	ruleDiff := ruleDifference(actualRules, expectedRules)
+	for _, rule := range ruleDiff {
+		reportMapping[rule.File] = &alertsTestReport{
+			AdditionalRules: rule.Rules,
+			Status:          fileAdditional,
+		}
+	}
+
+	// missing file
+	// if an expected file is not found, add it to the reportMapping
+	ruleDiff = ruleDifference(expectedRules, actualRules)
+	for _, rule := range ruleDiff {
+		reportMapping[rule.File] = &alertsTestReport{
+			MissingRules: rule.Rules,
+			Status:       fileMissing,
+		}
+	}
+
+	// the file exists, do left and right diffs to ensure
+	// all rules exist and no unexpected rules are found
+	for _, actualRule := range actualRules {
+		for _, expectedRule := range expectedRules {
+			if actualRule.File == expectedRule.File {
+				reportMapping[actualRule.File] = buildReport(actualRule, expectedRule, reportMapping[actualRule.File])
+			}
+		}
+	}
+
+	// report the status
+	missingCount := 0
+	extraCount := 0
+	for k, v := range reportMapping {
+		if v.Status != fileCorrect {
+			t.Log("\nFile Name:", k)
+			t.Log("Missing Rules:", v.MissingRules)
+			t.Log("Unexpected Rules:", v.AdditionalRules)
+			t.Log("Status:", v.Status)
+		}
+		if v.Status == fileMissing || len(v.MissingRules) > 0 {
+			missingCount++
+		}
+		if v.Status == fileAdditional || len(v.AdditionalRules) > 0 {
+			extraCount++
+		}
+	}
+
+	if missingCount > 0 {
+		t.Log("\nMissing alerts were found from Prometheus. If the removal of these Alert rules was intentional, please update this test to remove them from the check. If the removal of these Alert rules was not intendended or you are not sure, please create a Jira & discuss with the monitoring team on how best to proceed")
+	}
+	if extraCount > 0 {
+		t.Log("\nUnexpected alerts were found in Prometheus. If these Alert rules were intentionally added, please update this test to add them to the check. If these Alert rules were not added intentionally or you are not sure, please create a Jira & discuss with the monitoring team on how best to proceed.")
+	}
+	if extraCount > 0 || missingCount > 0 {
+		t.Fatal("Found missing or too many alerts")
+	}
+}
+
+func getExpectedAWSRules(installType string, installationName string) []alertsTestRule {
+	if installType == string(rhmiv1alpha1.InstallationTypeManagedApi) {
+		return append(commonExpectedAWSRules(installationName), managedApiAwsExpectedRules(installationName)...)
+	} else {
+		return append(commonExpectedAWSRules(installationName), rhmi2ExpectedAWSRules(installationName)...)
+	}
+}
+
+func getExpectedRules(installType string) []alertsTestRule {
+	if installType == string(rhmiv1alpha1.InstallationTypeManagedApi) {
+		return append(commonExpectedRules(), managedApiSpecificRules()...)
+	} else {
+		return append(commonExpectedRules(), rhmi2ExpectedRules()...)
+	}
+}
+
+// ruleDifference one-way diff that return rules in diffSource that are not in diffTarget
+func ruleDifference(diffSource, diffTarget []alertsTestRule) []alertsTestRule {
+	// create an empty lookup map with keys from diffTarget
+	diffSourceLookupMap := make(map[string]struct{}, len(diffTarget))
+	for _, rule := range diffTarget {
+		diffSourceLookupMap[rule.File] = struct{}{}
+	}
+	// use the lookup map to find items in diffSource that are not in diffTarget
+	// and store them in a diff slice
+	var diff []alertsTestRule
+	for _, rule := range diffSource {
+		if _, found := diffSourceLookupMap[rule.File]; !found {
+			diff = append(diff, rule)
+		}
+	}
+	return diff
+}
+
+// build report builds up a report of missing or unexpected rules for a given file name
+func buildReport(actualRule, expectedRule alertsTestRule, report *alertsTestReport) *alertsTestReport {
+	// pre-req
+	if report == nil {
+		report = newDefaultReport(fileCorrect)
+	}
+	// build report
+	report.MissingRules = append(report.MissingRules, difference(expectedRule.Rules, actualRule.Rules)...)
+	report.AdditionalRules = append(report.AdditionalRules, difference(actualRule.Rules, expectedRule.Rules)...)
+	if len(report.MissingRules) != 0 || len(report.AdditionalRules) != 0 {
+		report.Status = fileExists
+	}
+	return report
+}
+
+// difference one-way diff that return strings in sliceSource that are not in sliceTarget
+func difference(sliceSource, sliceTarget []string) []string {
+	// create an empty lookup map with keys from sliceTarget
+	diffSourceLookupMap := make(map[string]struct{}, len(sliceTarget))
+	for _, item := range sliceTarget {
+		diffSourceLookupMap[item] = struct{}{}
+	}
+	// use the lookup map to find items in sliceSource that are not in sliceTarget
+	// and store them in a diff slice
+	var diff []string
+	for _, item := range sliceSource {
+		if _, found := diffSourceLookupMap[item]; !found {
+			diff = append(diff, item)
+		}
+	}
+	return diff
+}

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -1,0 +1,287 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	goctx "context"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const deadMansSwitch = "DeadMansSwitch"
+
+// alertsTestMetadata contains metadata about the alert
+type alertTestMetadata struct {
+	alertName string
+	podName   string
+	namespace string
+}
+
+// alertsFiringError is a custom alerts error
+type alertsFiringError struct {
+	alertsPending        []alertTestMetadata
+	alertsFiring         []alertTestMetadata
+	deadMansSwitchFiring bool
+}
+
+var (
+	// Applicable to RHOAM
+	rhoamExpectedPodNamespaces = []string{
+		Marin3rOperatorNamespace,
+		Marin3rProductNamespace,
+		CustomerGrafanaNamespace,
+	}
+
+	// Applicable to all install types
+	commonPodNamespaces = []string{
+		RHMIOperatorNamespace,
+		MonitoringOperatorNamespace,
+		MonitoringFederateNamespace,
+		CloudResourceOperatorNamespace,
+		RHSSOUserProductOperatorNamespace,
+		RHSSOUserOperatorNamespace,
+		RHSSOProductNamespace,
+		RHSSOOperatorNamespace,
+		ThreeScaleProductNamespace,
+		ThreeScaleOperatorNamespace,
+	}
+	// Applicable to rhmi 2 install types only
+	rhmi2PodNamespaces = []string{
+		AMQOnlineOperatorNamespace,
+		ApicuritoProductNamespace,
+		ApicuritoOperatorNamespace,
+		CodeReadyProductNamespace,
+		CodeReadyOperatorNamespace,
+		FuseProductNamespace,
+		FuseOperatorNamespace,
+		SolutionExplorerProductNamespace,
+		SolutionExplorerOperatorNamespace,
+		UPSProductNamespace,
+		UPSOperatorNamespace,
+	}
+)
+
+// Error implements the error interface and returns a readable output message
+func (e *alertsFiringError) Error() string {
+	var str strings.Builder
+
+	if e.deadMansSwitchFiring {
+		str.WriteString("\nThe following alerts were not fired, but were expected to be firing:")
+		str.WriteString(fmt.Sprintf("\n\talert: %s", deadMansSwitch))
+	}
+	if len(e.alertsPending) != 0 {
+		str.WriteString("\nThe following alerts were pending:")
+		for _, alert := range e.alertsPending {
+			str.WriteString(fmt.Sprintf("\n\talert: %s", alert.alertName))
+			if alert.podName != "" {
+				str.WriteString(fmt.Sprintf(", for pod: %s, in namespace: %s", alert.podName, alert.namespace))
+			}
+		}
+	}
+	if len(e.alertsFiring) != 0 {
+		str.WriteString("\nThe following alerts were fired:")
+		for _, alert := range e.alertsFiring {
+			str.WriteString(fmt.Sprintf("\n\talert: %s", alert.alertName))
+			if alert.podName != "" {
+				str.WriteString(fmt.Sprintf(", for pod: %s, in namespace: %s", alert.podName, alert.namespace))
+			}
+		}
+	}
+	return str.String()
+}
+
+// isNotEmpty checks whether or not the error contains firing or pending alerts
+func (e *alertsFiringError) isValid() bool {
+	return !e.deadMansSwitchFiring || len(e.alertsFiring) != 0 || len(e.alertsPending) != 0
+}
+
+// This test ensures that no alerts are firing during or after installation
+func TestIntegreatlyAlertsFiring(t TestingTB, ctx *TestingContext) {
+	//fail immediately if one or more alerts have fired
+	if err := getFiringAlerts(t, ctx); err != nil {
+		podLogs(t, ctx)
+		t.Skip("Skipping due to known flaky behavior due to, reported in Jira: https://issues.redhat.com/browse/INTLY-7481")
+		//t.Fatal(err.Error())
+	}
+
+}
+func getFiringAlerts(t TestingTB, ctx *TestingContext) error {
+	output, err := execToPod("curl localhost:9090/api/v1/alerts",
+		"prometheus-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"prometheus",
+		ctx)
+	if err != nil {
+		return fmt.Errorf("failed to exec to prometheus pod: %w", err)
+	}
+
+	// get all found rules from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+	var alertsResult prometheusv1.AlertsResult
+	err = json.Unmarshal(promApiCallOutput.Data, &alertsResult)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	// create a custom alerts error to keep track of all firing alerts
+	alertsError := &alertsFiringError{
+		alertsFiring:         []alertTestMetadata{},
+		deadMansSwitchFiring: true,
+	}
+
+	// // check if any alerts other than DeadMansSwitch are firing
+	for _, alert := range alertsResult.Alerts {
+		alertName := string(alert.Labels["alertname"])
+		alertMetadata := alertTestMetadata{
+			alertName: alertName,
+			podName:   string(alert.Labels["pod"]),
+			namespace: string(alert.Labels["namespace"]),
+		}
+
+		// check if dead mans switch is firing
+		if alertName == deadMansSwitch && alert.State != prometheusv1.AlertStateFiring {
+			alertsError.deadMansSwitchFiring = false
+		}
+		// check for firing alerts
+		if alertName != deadMansSwitch {
+			if alert.State == prometheusv1.AlertStateFiring {
+				alertsError.alertsFiring = append(alertsError.alertsFiring, alertMetadata)
+
+			}
+
+		}
+	}
+
+	if alertsError.isValid() {
+		return alertsError
+
+	}
+	return nil
+}
+
+// Makes a api call a to get all pods in the rhmi namespaces
+func podLogs(t TestingTB, ctx *TestingContext) {
+	pods := &corev1.PodList{}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+	podNamespaces := getPodNamespaces(rhmi.Spec.Type)
+
+	for _, namespaces := range podNamespaces {
+		err := ctx.Client.List(goctx.TODO(), pods, &k8sclient.ListOptions{Namespace: namespaces})
+		if err != nil {
+			t.Error("Error getting namespaces:", err)
+		}
+		t.Log("Namespace:", namespaces)
+		for _, pod := range pods.Items {
+			t.Logf("\tPod name: %s, Status: %s", pod.Name, pod.Status.Phase)
+		}
+	}
+}
+
+func getPodNamespaces(installType string) []string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(commonPodNamespaces, rhoamExpectedPodNamespaces...)
+	} else {
+		return append(commonPodNamespaces, rhmi2PodNamespaces...)
+	}
+}
+
+// TestIntegreatlyAlertsFiring reports any firing or pending alerts
+func TestIntegreatlyAlertsPendingOrFiring(t TestingTB, ctx *TestingContext) {
+	var lastError error
+
+	// retry the tests every minute for up to 15 minutes
+	monitoringTimeout := 15 * time.Minute
+	monitoringRetryInterval := 1 * time.Minute
+	err := wait.Poll(monitoringRetryInterval, monitoringTimeout, func() (done bool, err error) {
+		if newErr := getFiringOrPendingAlerts(ctx); newErr != nil {
+			lastError = newErr
+			if _, ok := newErr.(*alertsFiringError); ok {
+				t.Log("Waiting 1 minute for alerts to normalise before retrying")
+				return false, nil
+			}
+			return false, newErr
+		}
+		return true, nil
+	},
+	)
+	if err != nil {
+		podLogs(t, ctx)
+		t.Skipf("Skipping due to known flaky behavior due to %v, Jira: https://issues.redhat.com/browse/INTLY-7481", lastError.Error())
+		//t.Fatal(lastError.Error())
+	}
+}
+
+func getFiringOrPendingAlerts(ctx *TestingContext) error {
+	output, err := execToPod("curl localhost:9090/api/v1/alerts",
+		"prometheus-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"prometheus",
+		ctx)
+	if err != nil {
+		return fmt.Errorf("failed to exec to prometheus pod: %w", err)
+	}
+
+	// get all found rules from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+	var alertsResult prometheusv1.AlertsResult
+	err = json.Unmarshal(promApiCallOutput.Data, &alertsResult)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	// create a custom alerts error to keep track of all pending and firing alerts
+	alertsError := &alertsFiringError{
+		alertsPending:        []alertTestMetadata{},
+		alertsFiring:         []alertTestMetadata{},
+		deadMansSwitchFiring: true,
+	}
+
+	// check if any alerts other than DeadMansSwitch are firing or pending
+	for _, alert := range alertsResult.Alerts {
+		alertName := string(alert.Labels["alertname"])
+		alertMetadata := alertTestMetadata{
+			alertName: alertName,
+			podName:   string(alert.Labels["pod"]),
+			namespace: string(alert.Labels["namespace"]),
+		}
+
+		// check if dead mans switch is firing
+		if alertName == deadMansSwitch && alert.State != prometheusv1.AlertStateFiring {
+			alertsError.deadMansSwitchFiring = false
+		}
+		// check for pending or firing alerts
+		if alertName != deadMansSwitch {
+			if alert.State == prometheusv1.AlertStateFiring {
+				alertsError.alertsFiring = append(alertsError.alertsFiring, alertMetadata)
+			}
+			if alert.State == prometheusv1.AlertStatePending {
+				alertsError.alertsPending = append(alertsError.alertsPending, alertMetadata)
+			}
+		}
+	}
+	if alertsError.isValid() {
+		return alertsError
+
+	}
+	return nil
+}

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -1,0 +1,404 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type repeatFunc func()
+
+type alertManagerConfig struct {
+	Global struct {
+		SMTPSmartHost    string `yaml:"smtp_smarthost"`
+		SMTPAuthUsername string `yaml:"smtp_auth_username"`
+		SMTPAuthPassword string `yaml:"smtp_auth_password"`
+	} `yaml:"global"`
+
+	Receivers []map[string]interface{} `yaml:"receivers"`
+}
+
+const (
+	threescaleOperatorDeploymentName          = "3scale-operator"
+	threescaleApicastProdDeploymentConfigName = "apicast-production"
+	monitoringTimeout                         = time.Minute * 40
+	monitoringRetryInterval                   = time.Minute
+	verifyOperatorDeploymentTimeout           = time.Minute * 5
+	verifyOperatorDeploymentRetryInterval     = time.Second * 15
+)
+
+var threescaleAlertsToTest = map[string]string{
+	"RHMIThreeScaleApicastProductionServiceEndpointDown": "none",
+	"ThreeScaleApicastProductionPod":                     "none",
+}
+
+// TestIntegreatlyAlertsMechanism verifies that alert mechanism works
+func TestIntegreatlyAlertsMechanism(t TestingTB, ctx *TestingContext) {
+
+	originalOperatorReplicas, err := getNumOfReplicasDeployment(threescaleOperatorDeploymentName, ctx.KubeClient)
+	if err != nil {
+		t.Errorf("failed to get number of replicas: %s", err)
+	}
+
+	// verify that alert to be tested is not firing before starting the test
+	err = getThreescaleAlertState(ctx)
+	if err != nil {
+		t.Fatal("failed to get threescale alert state", err)
+	}
+
+	threescaleAlertsFiring := false
+
+	for threescaleAlertName, threescaleAlertState := range threescaleAlertsToTest {
+		if threescaleAlertState != "none" {
+			threescaleAlertsFiring = true
+			t.Errorf("%s alert should not be firing", threescaleAlertName)
+		}
+	}
+
+	if threescaleAlertsFiring {
+		t.FailNow()
+	}
+
+	// scale down Threescale operator and product pods and verify that threescale alert is firing
+	err = performTest(t, ctx, originalOperatorReplicas)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the operator has been scaled backup
+	err = checkThreescaleOperatorReplicasAreReady(ctx, t, originalOperatorReplicas)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify that threescale alert is not firing
+	err = waitForThreescaleAlertState("none", ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify alertmanager-application-monitoring secret
+	err = verifySecrets(ctx.KubeClient)
+	if err != nil {
+		t.Fatal("failed to verify alertmanager-application-monitoring secret", err)
+	}
+}
+
+func verifySecrets(kubeClient kubernetes.Interface) error {
+	var pagerdutyKey, dmsURL string
+	res, err := kubeClient.CoreV1().Secrets(RHMIOperatorNamespace).Get(context.TODO(), NamespacePrefix+"deadmanssnitch", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret: %w", err)
+	}
+	if len(res.Data["SNITCH_URL"]) != 0 {
+		dmsURL = string(res.Data["SNITCH_URL"])
+	} else if len(res.Data["url"]) != 0 {
+		dmsURL = string(res.Data["url"])
+	} else {
+		return fmt.Errorf("url is undefined in dead mans snitch secret")
+	}
+
+	res, err = kubeClient.CoreV1().Secrets(RHMIOperatorNamespace).Get(context.TODO(), NamespacePrefix+"pagerduty", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	if len(res.Data["PAGERDUTY_KEY"]) != 0 {
+		pagerdutyKey = string(res.Data["PAGERDUTY_KEY"])
+	} else if len(res.Data["serviceKey"]) != 0 {
+		pagerdutyKey = string(res.Data["serviceKey"])
+	} else {
+		return fmt.Errorf("secret key is undefined in pager duty secret")
+	}
+
+	res, err = kubeClient.CoreV1().Secrets(RHMIOperatorNamespace).Get(context.TODO(), NamespacePrefix+"smtp", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret: %w", err)
+	}
+	smtp := res.Data
+
+	res, err = kubeClient.CoreV1().Secrets(MonitoringOperatorNamespace).Get(context.TODO(), "alertmanager-application-monitoring", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret: %w", err)
+	}
+	monitoring := res.Data["alertmanager.yaml"]
+
+	var config alertManagerConfig
+	err = yaml.Unmarshal(monitoring, &config)
+	if err != nil {
+		return fmt.Errorf("failed to parse yaml: %w", err)
+	}
+
+	if config.Global.SMTPSmartHost != string(smtp["host"])+":"+string(smtp["port"]) {
+		return fmt.Errorf("smtp_smarthost not set correctly")
+	}
+	if config.Global.SMTPAuthUsername != string(smtp["username"]) {
+		return fmt.Errorf("smtp_auth_username not set correctly")
+	}
+	if config.Global.SMTPAuthPassword != string(smtp["password"]) {
+		return fmt.Errorf("smtp_auth_password not set correctly")
+	}
+
+	for _, receiver := range config.Receivers {
+		switch receiver["name"] {
+		case "critical":
+			configs := receiver["pagerduty_configs"].([]interface{})
+			if configs[0].(map[interface{}]interface{})["service_key"] != pagerdutyKey {
+				return fmt.Errorf("pagerduty service_key not set correctly")
+			}
+		case "deadmansswitch":
+			configs := receiver["webhook_configs"].([]interface{})
+			if configs[0].(map[interface{}]interface{})["url"] != dmsURL {
+				return fmt.Errorf("dms url not set correctly")
+			}
+		}
+	}
+
+	return nil
+}
+
+func performTest(t TestingTB, ctx *TestingContext, originalOperatorReplicas int32) error {
+	originalUIReplicas, err := getNumOfReplicasDeploymentConfig(threescaleApicastProdDeploymentConfigName, ThreeScaleProductNamespace, ctx.Client)
+	if err != nil {
+		t.Errorf("failed to get number of replicas: %s", err)
+	}
+
+	quit1 := make(chan struct{})
+	go repeat(func() {
+		scaleDeployment(threescaleOperatorDeploymentName, 0, ctx.KubeClient)
+	}, quit1)
+	defer close(quit1)
+	defer scaleDeployment(threescaleOperatorDeploymentName, originalOperatorReplicas, ctx.KubeClient)
+
+	quit2 := make(chan struct{})
+	go repeat(func() {
+		scaleDeploymentConfig(threescaleApicastProdDeploymentConfigName, ThreeScaleProductNamespace, 0, ctx.Client)
+	}, quit2)
+	defer close(quit2)
+	defer scaleDeploymentConfig(threescaleApicastProdDeploymentConfigName, ThreeScaleProductNamespace, originalUIReplicas, ctx.Client)
+
+	err = waitForThreescaleAlertState("pending", ctx, t)
+	if err != nil {
+		return err
+	}
+
+	err = waitForThreescaleAlertState("firing", ctx, t)
+	if err != nil {
+		return err
+	}
+
+	err = checkAlertManager(ctx, t)
+	return err
+}
+
+func checkAlertManager(ctx *TestingContext, t TestingTB) error {
+	output, err := execToPod("amtool alert --alertmanager.url=http://localhost:9093",
+		"alertmanager-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"alertmanager",
+		ctx)
+	if err != nil {
+		return fmt.Errorf("failed to exec to alertmanger pod: %w", err)
+	}
+
+	alertsNotFiringInAlertManager := false
+	for threescaleAlertName := range threescaleAlertsToTest {
+		if !strings.Contains(output, threescaleAlertName) {
+			alertsNotFiringInAlertManager = true
+			t.Errorf("%s alert not firing in alertmanager", threescaleAlertName)
+		}
+	}
+
+	if alertsNotFiringInAlertManager {
+		t.FailNow()
+	}
+
+	return nil
+}
+
+func repeat(function repeatFunc, quit chan struct{}) {
+	for {
+		select {
+		case <-quit:
+			return
+		default:
+			function()
+		}
+	}
+}
+
+func waitForThreescaleAlertState(expectedState string, ctx *TestingContext, t TestingTB) error {
+	err := wait.PollImmediate(monitoringRetryInterval, monitoringTimeout, func() (done bool, err error) {
+		err = getThreescaleAlertState(ctx)
+		if err != nil {
+			t.Log("failed to get threescale alert state:", err)
+			t.Log("waiting 1 minute before retrying")
+			return false, nil
+		}
+
+		alertsInExpectedState := true
+		for threescaleAlertName, threescaleAlertState := range threescaleAlertsToTest {
+			if threescaleAlertState != expectedState {
+				alertsInExpectedState = false
+				t.Logf("%s alert is not in expected state (%s) yet, current state: %s", threescaleAlertName, expectedState, threescaleAlertState)
+				t.Log("waiting 1 minute before retrying")
+			}
+		}
+
+		if alertsInExpectedState {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	return err
+}
+
+func getThreescaleAlertState(ctx *TestingContext) error {
+	output, err := execToPod("curl localhost:9090/api/v1/alerts",
+		"prometheus-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"prometheus",
+		ctx)
+	if err != nil {
+		return fmt.Errorf("failed to exec to prometheus pod: %w", err)
+	}
+
+	var promAPICallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promAPICallOutput)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	var alertsResult prometheusv1.AlertsResult
+	err = json.Unmarshal(promAPICallOutput.Data, &alertsResult)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	for threescaleAlertName := range threescaleAlertsToTest {
+		threescaleAlertsToTest[threescaleAlertName] = "none"
+	}
+
+	for _, alert := range alertsResult.Alerts {
+		alertName := string(alert.Labels["alertname"])
+
+		for threescaleAlertName := range threescaleAlertsToTest {
+			if alertName == threescaleAlertName {
+				threescaleAlertsToTest[threescaleAlertName] = string(alert.State)
+			}
+		}
+	}
+
+	return nil
+}
+
+func getNumOfReplicasDeployment(name string, kubeClient kubernetes.Interface) (int32, error) {
+	deploymentsClient := kubeClient.AppsV1().Deployments(ThreeScaleOperatorNamespace)
+
+	result, getErr := deploymentsClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if getErr != nil {
+		return 0, fmt.Errorf("failed to get latest version of Deployment: %v", getErr)
+	}
+
+	return *result.Spec.Replicas, nil
+}
+
+func getNumOfReplicasDeploymentConfig(name string, namespace string, client client.Client) (int32, error) {
+	deploymentConfig := &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	getErr := client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, deploymentConfig)
+	if getErr != nil {
+		return 0, fmt.Errorf("failed to get DeploymentConfig %s in namespace %s with error: %s", name, namespace, getErr)
+	}
+
+	return deploymentConfig.Spec.Replicas, nil
+}
+
+func scaleDeployment(name string, replicas int32, kubeClient kubernetes.Interface) error {
+	deploymentsClient := kubeClient.AppsV1().Deployments(ThreeScaleOperatorNamespace)
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, getErr := deploymentsClient.Get(context.TODO(), name, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to get latest version of Deployment: %v", getErr)
+		}
+
+		result.Spec.Replicas = &replicas
+		_, updateErr := deploymentsClient.Update(context.TODO(), result, metav1.UpdateOptions{})
+		return updateErr
+	})
+	if retryErr != nil {
+		return fmt.Errorf("update failed: %v", retryErr)
+	}
+
+	return nil
+}
+
+func scaleDeploymentConfig(name string, namespace string, replicas int32, client client.Client) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deploymentConfig := &appsv1.DeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		getErr := client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, deploymentConfig)
+		if getErr != nil {
+			return fmt.Errorf("failed to get DeploymentConfig %s in namespace %s with error: %s", name, namespace, getErr)
+		}
+
+		deploymentConfig.Spec.Replicas = replicas
+		updateErr := client.Update(goctx.TODO(), deploymentConfig)
+		return updateErr
+	})
+	if retryErr != nil {
+		return fmt.Errorf("update failed: %v", retryErr)
+	}
+
+	return nil
+}
+
+func checkThreescaleOperatorReplicasAreReady(ctx *TestingContext, t TestingTB, originalOperatorReplicas int32) error {
+	t.Logf("Checking correct number of threescale operator replicas (%d) are set", originalOperatorReplicas)
+	err := wait.Poll(verifyOperatorDeploymentRetryInterval, verifyOperatorDeploymentTimeout, func() (done bool, err error) {
+		numberOfOperatorReplicas, err := getNumOfReplicasDeployment(threescaleOperatorDeploymentName, ctx.KubeClient)
+
+		if numberOfOperatorReplicas == originalOperatorReplicas {
+			t.Log("Threescale operator deployment ready")
+			return true, nil
+		}
+
+		if numberOfOperatorReplicas == 0 {
+			t.Log("Threescale operator deployment not yet scaled, waiting 15 seconds before retrying")
+			scaleDeployment(threescaleOperatorDeploymentName, originalOperatorReplicas, ctx.KubeClient)
+			return false, nil
+		}
+
+		return false, err
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/common/apicurio_registry_crud.go
+++ b/test/common/apicurio_registry_crud.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"context"
+
+	apicurioregistry "github.com/Apicurio/apicurio-registry-operator/pkg/apis/apicur/v1alpha1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	"k8s.io/apimachinery/pkg/types"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	artifactID   = "share-price"
+	artifactType = resources.Avro
+	artifactData = "{\"type\":\"record\",\"name\":\"price\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"symbol\",\"type\":\"string\"},{\"name\":\"price\",\"type\":\"string\"}]}"
+)
+
+// TestApicurioRegistryAPI tests the ApicurioRegistry API
+func TestApicurioRegistryAPI(t TestingTB, ctx *TestingContext) {
+	host, err := getHost(ctx.Client)
+	if err != nil {
+		t.Fatalf("error getting ApicurioRegistry CR: %v", err)
+	}
+
+	apiClient := resources.NewApicurioRegistryApiClient(host, ctx.HttpClient)
+
+	err = apiClient.CreateArtifact(artifactID, artifactType, artifactData)
+	if err != nil {
+		t.Fatalf("error creating artifact: %v", err)
+	}
+
+	data, err := apiClient.ReadArtifact(artifactID)
+	if err != nil {
+		t.Fatalf("error reading artifact: %v", err)
+	}
+	if data != artifactData {
+		t.Fatalf("unexpected artifact data: %v", data)
+	}
+
+	err = apiClient.DeleteArtifact(artifactID)
+	if err != nil {
+		t.Fatalf("error deleting artifact: %v", err)
+	}
+}
+
+func getHost(client dynclient.Client) (string, error) {
+	apicurioRegistry := &apicurioregistry.ApicurioRegistry{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: string(integreatlyv1alpha1.ProductApicurioRegistry), Namespace: ApicurioRegistryProductNamespace}, apicurioRegistry)
+	if err != nil {
+		return "", err
+	}
+	return apicurioRegistry.Status.Host, nil
+}

--- a/test/common/authdelay_first_broker_login.go
+++ b/test/common/authdelay_first_broker_login.go
@@ -1,0 +1,325 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/headzoo/surf"
+	"github.com/headzoo/surf/browser"
+	brow "github.com/headzoo/surf/browser"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TestAuthThreeScaleUsername = "testauth-threescale"
+	threeScaleDashboardURI     = "p/admin/dashboard"
+	threeScaleOnboardingURI    = "p/admin/onboarding/wizard/intro"
+)
+
+func TestAuthDelayFirstBrokerLogin(t TestingTB, ctx *TestingContext) {
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	testUser, err := getRandomKeycloakUser(ctx, rhmi.Name)
+
+	if err != nil {
+		t.Fatalf("error getting test user: %v", err)
+	}
+
+	tsHost := rhmi.Status.Stages[v1alpha1.ProductsStage].Products[v1alpha1.Product3Scale].Host
+	if tsHost == "" {
+		tsHost = fmt.Sprintf("https://3scale-admin.%v", rhmi.Spec.RoutingSubdomain)
+	}
+	t.Logf("Three scale admin host %s", tsHost)
+
+	err = ensureKeycloakUserIsReconciled(goctx.TODO(), ctx.Client, testUser.UserName)
+	if err != nil {
+		t.Fatalf("error occurred while waiting on keycloak user to be reconciled: %v", err)
+	}
+
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = loginToThreeScale(t, tsHost, testUser.UserName, DefaultPassword, TestingIDPRealm, httpClient)
+	if err != nil {
+		t.Fatalf("[%s] error logging in to three scale: %v", getTimeStampPrefix(), err)
+	}
+}
+
+func getRandomKeycloakUser(ctx *TestingContext, installationName string) (*TestUser, error) {
+	// create random keycloak user
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+	userNamePostfix := r1.Intn(100000)
+	testUsers := []TestUser{
+		{
+			FirstName: TestAuthThreeScaleUsername,
+			LastName:  fmt.Sprintf("User %d", userNamePostfix),
+			UserName:  fmt.Sprintf("%s-%d", TestAuthThreeScaleUsername, userNamePostfix),
+		},
+	}
+	err := createOrUpdateKeycloakUserCR(goctx.TODO(), ctx.Client, testUsers, installationName)
+	if err != nil {
+		return nil, fmt.Errorf("error creating test user: %v", err)
+	}
+
+	var adminUsers = []string{
+		fmt.Sprintf("%s-%d", TestAuthThreeScaleUsername, userNamePostfix),
+	}
+	err = createOrUpdateDedicatedAdminGroupCR(goctx.TODO(), ctx.Client, adminUsers)
+	if err != nil {
+		return nil, fmt.Errorf("error adding user to dedicated admin group: %v", err)
+	}
+
+	return &testUsers[0], nil
+}
+
+// polls the keycloak user until it is ready
+func ensureKeycloakUserIsReconciled(ctx context.Context, client dynclient.Client, keycloakUsername string) error {
+	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		keycloakUser := &keycloak.KeycloakUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", TestingIDPRealm, keycloakUsername),
+				Namespace: fmt.Sprintf("%srhsso", NamespacePrefix),
+			},
+		}
+
+		if err := client.Get(ctx, types.NamespacedName{Name: keycloakUser.GetName(), Namespace: keycloakUser.GetNamespace()}, keycloakUser); err != nil {
+			return true, fmt.Errorf("error occurred while getting keycloak user")
+		}
+		if keycloakUser.Status.Phase == "reconciled" {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error occurred while polling keycloak user: %w", err)
+	}
+	return nil
+}
+
+func loginToThreeScale(t TestingTB, tsHost, username, password string, idp string, client *http.Client) error {
+
+	// const variable to validate authentication
+	const (
+		provisioningAccountTxt = "Your account is being provisioned"
+	)
+
+	parsedURL, err := url.Parse(tsHost)
+	if err != nil {
+		return fmt.Errorf("failed to parse three scale url %s: %s", parsedURL, err)
+	}
+
+	if parsedURL.Scheme == "" {
+		tsHost = fmt.Sprintf("https://%s", tsHost)
+	}
+
+	tsLoginURL := fmt.Sprintf("%v/p/login", tsHost)
+	tsDashboardURL := fmt.Sprintf("%v/%s", tsHost, threeScaleDashboardURI)
+
+	t.Logf("Attempting to open threescale login page with url: %s", tsLoginURL)
+
+	browser := surf.NewBrowser()
+	browser.SetCookieJar(client.Jar)
+	browser.SetTransport(client.Transport)
+	browser.SetAttribute(brow.FollowRedirects, true)
+
+	// open threescale login page
+	err = browser.Open(tsLoginURL)
+	if err != nil {
+		return fmt.Errorf("failed to open browser url: %w", err)
+	}
+
+	// check if user is already authenticated
+	if isUserAuthenticated(browser, tsDashboardURL) {
+		return nil
+	}
+
+	t.Logf("User is not authenticated yet, going to authenticate through rhsso url  %s", browser.Url().String())
+
+	// click on authenticate through rhsso
+	err = authenticateThroughRHSSO(browser)
+	if err != nil {
+		t.Logf("response %s", browser.Body())
+		return err
+	}
+
+	// check if user is already authenticated through rhsso
+	if isUserAuthenticated(browser, tsDashboardURL) {
+		return nil
+	}
+
+	t.Logf("User is not authenticated through rhsso yet, going to select the IDP %s", browser.Url().String())
+
+	selectIDPURL := browser.Url().String()
+	// select the IDP to authenticate through RHSSO
+	err = selectRHSSOIDP(browser, idp)
+	if err != nil {
+		return err
+	}
+
+	// check if user is already authenticated after selecting the IDP
+	if isUserAuthenticated(browser, tsDashboardURL) {
+		return nil
+	}
+
+	t.Logf("User is not authenticated after selecting the IDP yet, going to submit the form to authenticate the user through rhsso %s", browser.Url().String())
+
+	// submit openshift oauth login form
+	err = browser.Open(selectIDPURL)
+	if err != nil {
+		return fmt.Errorf("failed to open selectIDPURL url: %w", err)
+	}
+	err = resources.OpenshiftClientSubmitForm(browser, username, password, idp, t)
+	if err != nil {
+		return fmt.Errorf("failed to submit the openshift oauth login: %w", err)
+	}
+
+	// check if user is authenticated after submiting rhsso login form
+	if isUserAuthenticated(browser, tsDashboardURL) {
+		return nil
+	}
+
+	// waits until the account is provisioned and user is authenticated in three scale
+	err = wait.Poll(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		t.Logf("browser URL first %s - URL with requestURI %s, status code %v", browser.Url().String(), browser.Url().RequestURI(), browser.StatusCode())
+
+		// checks if an error happened in the login
+		if browser.StatusCode() == 502 {
+			t.Logf("Unexpected error, User already authenticated: URL - %s | Request status code - %v", browser.Url().String(), browser.StatusCode())
+
+			err := browser.Open(tsDashboardURL)
+			t.Logf("Opened dashboard URL to validate user authentication: URL - %s | DashboardURL - %s", browser.Url().String(), tsDashboardURL)
+			if err != nil {
+				t.Logf("failed to open dashboard url: %w", err)
+				return false, fmt.Errorf("failed to open dashboard url: %w", err)
+			}
+
+			// if user is redirected to the login page try again
+			if browser.Url().String() == tsLoginURL {
+				// click on authenticate through rhsso
+				err = authenticateThroughRHSSO(browser)
+				if err != nil {
+					return false, err
+				}
+
+				// check if user is already authenticated through rhsso
+				if isUserAuthenticated(browser, tsDashboardURL) {
+					return true, nil
+				}
+
+				selectIDPURL = browser.Url().String()
+				// select the IDP to authenticate through RHSSO
+				err = selectRHSSOIDP(browser, idp)
+				if err != nil {
+					return false, err
+				}
+
+				// check if user is already authenticated after selecting the IDP
+				if isUserAuthenticated(browser, tsDashboardURL) {
+					return true, nil
+				}
+				t.Logf("authenticate after click on idp url: %s", browser.Url().String())
+			}
+		}
+
+		if isUserAuthenticated(browser, tsDashboardURL) {
+			return true, nil
+		}
+
+		browser.Find(fmt.Sprintf("h1:contains('%s')", provisioningAccountTxt)).Each(func(index int, s *goquery.Selection) {
+
+			// gets the refresh url from the meta tag
+			browser.Dom().Find("meta").Each(func(index int, s *goquery.Selection) {
+				val, exist := s.Attr("content")
+				if exist {
+					contentValue := strings.Split(val, ";")
+					if len(contentValue) > 0 {
+						browser.Open(contentValue[1])
+						t.Logf("open new url after creating user in rhsso url: %s", browser.Url().String())
+					}
+				}
+			})
+		})
+
+		t.Logf("request status code %v , browser response", browser.StatusCode())
+
+		return isUserAuthenticated(browser, tsDashboardURL), nil
+	})
+
+	if err != nil {
+		errLogin := browser.Open(tsDashboardURL)
+		if errLogin != nil {
+			t.Logf("failed to open dashboard url: %w", err)
+		}
+		if !isUserAuthenticated(browser, tsDashboardURL) {
+			return fmt.Errorf("Account was not provisioned: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// checks if user is authenticated according to the browser url
+func isUserAuthenticated(browser *browser.Browser, tsDashboardURL string) bool {
+
+	// Check if the request returns 302
+	// which means that the user is already authenticated
+	if browser.StatusCode() == 302 {
+		// opens landing page
+		err := browser.Open(tsDashboardURL)
+		if err != nil {
+			return false
+		}
+	}
+
+	// checks if user is redirected to the lading page
+	return strings.Contains(browser.Url().RequestURI(), threeScaleDashboardURI) ||
+		strings.Contains(browser.Url().RequestURI(), threeScaleOnboardingURI)
+
+}
+
+func authenticateThroughRHSSO(browser *browser.Browser) error {
+	// click on authenticate throught rhsso
+	err := browser.Click("a.authorizeLink")
+	if err != nil {
+		return fmt.Errorf("failed to click on a.authorizeLink to authenticate throught rhsso: %w", err)
+	}
+
+	return nil
+}
+
+func selectRHSSOIDP(browser *browser.Browser, idp string) error {
+	browser.Find("noscript").Each(func(i int, selection *goquery.Selection) {
+		selection.SetHtml(selection.Text())
+	})
+	if err := browser.Click(fmt.Sprintf("a:contains('%s')", idp)); err != nil {
+		return fmt.Errorf("failed to click testing-idp identity provider in oauth proxy login, ensure the identity provider exists on the cluster: %w", err)
+	}
+
+	return nil
+}

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -1,0 +1,300 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	v1 "github.com/openshift/api/route/v1"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CheDevFile struct {
+	ApiVersion string      `yaml:"apiVersion" json:"apiVersion"`
+	Metadata   Metadata    `yaml:"metadata" json:"metadata"`
+	Commands   []Command   `yaml:"commands,omitempty" json:"commands,omitempty"`
+	Components []Component `yaml:"components,omitempty" json:"components,omitempty"`
+	Projects   []Project   `yaml:"projects,omitempty" json:"projects,omitempty"`
+}
+
+type Metadata struct {
+	GenerateName string `yaml:"generateName" json:"generateName"`
+}
+
+type Command struct {
+	Name    string   `yaml:"name,omitempty" json:"name,omitempty"`
+	Actions []Action `yaml:"actions,omitempty" json:"actions,omitempty"`
+}
+
+type Action struct {
+	Command          string      `yaml:"command,omitempty" json:"command,omitempty"`
+	Component        string      `yaml:"component,omitempty" json:"component,omitempty"`
+	Type             string      `yaml:"type,omitempty" json:"type,omitempty"`
+	Workdir          string      `yaml:"workdir,omitempty" json:"workdir,omitempty"`
+	ReferenceContent interface{} `yaml:"referenceContent,omitempty" json:"referenceContent,omitempty"`
+}
+
+type Component struct {
+	Alias        string            `yaml:"alias,omitempty" json:"alias,omitempty"`
+	ID           string            `yaml:"id,omitempty" json:"id,omitempty"`
+	Endpoints    []Endpoint        `yaml:"endpoints,omitempty" json:"endpoints,omitempty"`
+	Env          []Env             `yaml:"env,omitempty" json:"env,omitempty"`
+	Image        string            `yaml:"image,omitempty" json:"image,omitempty"`
+	MemoryLimit  string            `yaml:"memoryLimit,omitempty" json:"memoryLimit,omitempty"`
+	MountSources bool              `yaml:"mountSources,omitempty" json:"mountSources,omitempty"`
+	Preferences  map[string]string `yaml:"preferences,omitempty" json:"preferences,omitempty"`
+	Type         string            `yaml:"type,omitempty" json:"type,omitempty"`
+}
+
+type Endpoint struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	Port int    `yaml:"port,omitempty" json:"port,omitempty"`
+}
+
+type Env struct {
+	Name  string `yaml:"name,omitempty" json:"name,omitempty"`
+	Value string `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+type Project struct {
+	ClonePath string        `yaml:"clonePath,omitempty" json:"clonePath,omitempty"`
+	Name      string        `yaml:"name,omitempty" json:"name,omitempty"`
+	Source    ProjectSource `yaml:"source,omitempty" json:"source,omitempty"`
+}
+
+type ProjectSource struct {
+	Type     string `yaml:"type,omitempty" json:"type,omitempty"`
+	Location string `yaml:"location,omitempty" json:"location,omitempty"`
+}
+
+const (
+	clientId                  = "che-client"
+	goDevFilePath             = "https://%v/devfiles/05_go/devfile.yaml"
+	devFileRegistryRouteName  = "devfile-registry"
+	codereadyProductNamespace = "codeready-workspaces"
+	workspaceStatusReady      = "RUNNING"
+	workspaceStatusStopped    = "STOPPED"
+)
+
+var (
+	username = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+	password = DefaultPassword
+)
+
+func TestCodereadyCrudlPermisssions(t TestingTB, ctx *TestingContext) {
+	t.Log("Test codeready workspace creation")
+
+	// Ensure testing-idp is available
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("failed to create testing idp: %v", err)
+	}
+
+	// Get the master, codeready and keycloak url from the rhmi status
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI CR: %v", err)
+	}
+	masterURL := rhmi.Spec.MasterURL
+	cheHost := rhmi.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductCodeReadyWorkspaces].Host
+	keycloakHost := rhmi.Status.Stages[integreatlyv1alpha1.AuthenticationStage].Products[integreatlyv1alpha1.ProductRHSSO].Host
+
+	// Get codeready access token to be used for API requests
+	redirectUrl := fmt.Sprintf("%v/dashboard/", cheHost)
+
+	// login to openshift
+	loginClient := resources.NewCodereadyLoginClient(ctx.HttpClient, ctx.Client, masterURL, TestingIDPRealm, username, password, t)
+	if err := loginClient.OpenshiftLogin(rhmi.Spec.NamespacePrefix); err != nil {
+		t.Fatalf("failed to login to openshift: %v", err)
+	}
+
+	// login to codeready
+	token, err := loginClient.CodereadyLogin(keycloakHost, redirectUrl)
+	if err != nil {
+		t.Fatalf("failed to login to codeready: %v", err)
+	}
+
+	// Get codeready api client
+	codereadyClient := resources.NewCodereadyApiClient(ctx.HttpClient, cheHost, token)
+	codereadyNamespace := fmt.Sprintf("%v%v", rhmi.Spec.NamespacePrefix, codereadyProductNamespace)
+
+	// Get Codeready Go dev file. This will be used as a payload to create a workspace
+	devfile, err := getDevFile(ctx.HttpClient, ctx.Client, codereadyNamespace)
+	if err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to get che devfile: %v", err.Error())
+	}
+
+	// Create a codeready workspace
+	workspaceID, err := codereadyClient.CreateWorkspace(devfile)
+	if err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to create a codeready workspace: %v", err)
+	}
+
+	// Ensure workspace starts successfully
+	createWorkspaceRetryInterval := time.Second * 20
+	createWorkspaceTimeout := time.Minute * 7
+	if err := waitForWorkspaceStatus(codereadyClient, createWorkspaceRetryInterval, createWorkspaceTimeout, workspaceID, workspaceStatusReady); err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to start codeready workspace %v: %v", workspaceID, err)
+	}
+
+	// Stop workspace before deleting
+	if err := codereadyClient.StopWorkspace(workspaceID); err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to stop codeready workspace %v: %v", workspaceID, err)
+	}
+
+	stopWorkspaceRetryInterval := time.Second * 10
+	stopWorkspaceTimeout := time.Minute * 3
+	if err := waitForWorkspaceStatus(codereadyClient, stopWorkspaceRetryInterval, stopWorkspaceTimeout, workspaceID, workspaceStatusStopped); err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to wait for '%v' workspace to stop: %v", workspaceID, err)
+	}
+
+	// Delete workspace
+	if err := codereadyClient.DeleteWorkspace(workspaceID); err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("failed to delete codeready workspace %v: %v", workspaceID, err)
+	}
+
+	// Workspace resources created in openshift should already be removed at this stage. Ensure these resources are removed
+	if err := ensureWorkspaceResourcesRemoved(ctx, workspaceID, codereadyNamespace); err != nil {
+		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6679")
+		//t.Fatalf("workspace resources still exists in the cluster: %v", err)
+	}
+}
+
+/*
+Codeready creates the following resources in openshift: deployments, pods, secrets, routes and services.
+This function returns an error if any of the resources created have not been removed from openshift.
+*/
+func ensureWorkspaceResourcesRemoved(ctx *TestingContext, workspaceId, namespace string) error {
+	labelSelector := fmt.Sprintf("che.workspace_id=%s", workspaceId)
+	listOpts := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	deployments, err := ctx.KubeClient.AppsV1().Deployments(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list deployments in %v namespace: %v", namespace, err)
+	}
+
+	if len(deployments.Items) != 0 {
+		return fmt.Errorf("there are %v workspace deployments remaining", len(deployments.Items))
+	}
+
+	pods, err := ctx.KubeClient.CoreV1().Pods(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list pods in %v namespace: %v", namespace, err)
+	}
+
+	if len(pods.Items) != 0 {
+		return fmt.Errorf("there are %v workspace pods remaining", len(pods.Items))
+	}
+
+	services, err := ctx.KubeClient.CoreV1().Services(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list services in %v namespace: %v", namespace, err)
+	}
+
+	if len(services.Items) != 0 {
+		return fmt.Errorf("there are %v workspace services remaining", len(services.Items))
+	}
+
+	secrets, err := ctx.KubeClient.CoreV1().Secrets(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets in %v namespace: %v", namespace, err)
+	}
+
+	if len(secrets.Items) != 0 {
+		return fmt.Errorf("there are %v worspace secrets remaining", len(secrets.Items))
+	}
+
+	routes := &v1.RouteList{}
+
+	label, err := labels.Parse(labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to parse label selector: %v", err)
+	}
+
+	if err := ctx.Client.List(goctx.TODO(), routes, &k8sclient.ListOptions{LabelSelector: label}); err != nil {
+		return fmt.Errorf("failed to list routes in %v namespace: %v", namespace, err)
+	}
+
+	if len(routes.Items) != 0 {
+		return fmt.Errorf("there are %v workspace routes remaining", len(routes.Items))
+	}
+
+	return nil
+}
+
+func waitForWorkspaceStatus(cheClient *resources.CodereadyApiClientImpl, retryInterval, timeout time.Duration, workspaceID, status string) error {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		workspace, err := cheClient.GetWorkspace(workspaceID)
+		if err != nil {
+			return false, fmt.Errorf("failed to get codeready workspace %v: %v", workspaceID, err)
+		}
+
+		if workspace.Status != status {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func getContentFromURL(httpClient *http.Client, url string) ([]byte, error) {
+	response, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get file content from %v. Status: %d", url, response.StatusCode)
+	}
+	defer response.Body.Close()
+
+	return ioutil.ReadAll(response.Body)
+}
+
+func getDevFile(httpClient *http.Client, dynClient k8sclient.Client, codereadyNamespace string) ([]byte, error) {
+	// Get Devfile registry route
+	devFileRegistryRoute := &v1.Route{}
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: devFileRegistryRouteName, Namespace: codereadyNamespace}, devFileRegistryRoute); err != nil {
+		return nil, fmt.Errorf("failed to get devfile registry route in %v namespace: %v", codereadyNamespace, err)
+	}
+
+	url := fmt.Sprintf(goDevFilePath, devFileRegistryRoute.Spec.Host)
+
+	fileContent, err := getContentFromURL(httpClient, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get content from url %v: %v", url, err.Error())
+	}
+
+	devFile := &CheDevFile{}
+	if err := yaml.Unmarshal(fileContent, &devFile); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal devfile content: %v", err.Error())
+	}
+
+	// Convert yaml to json
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false) // Ensures that characters such as '&' does not get converted to unicode
+	if err := encoder.Encode(devFile); err != nil {
+		return nil, fmt.Errorf("failed to encode: %v", err.Error())
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/test/common/crd_exists.go
+++ b/test/common/crd_exists.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"context"
+
+	"github.com/integr8ly/integreatly-operator/test/metadata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIntegreatlyCRDExists(t TestingTB, ctx *TestingContext) {
+	testCrdExists(t, ctx, "rhmis.integreatly.org")
+}
+
+func TestRHMIConfigCRDExists(t TestingTB, ctx *TestingContext) {
+	testCrdExists(t, ctx, "rhmiconfigs.integreatly.org")
+}
+
+func testCrdExists(t TestingTB, ctx *TestingContext, name string) {
+	_, err := ctx.ExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+		metadata.Instance.FoundCRD = false
+	} else {
+		metadata.Instance.FoundCRD = true
+	}
+}

--- a/test/common/cro_cr_success.go
+++ b/test/common/cro_cr_success.go
@@ -1,0 +1,197 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+)
+
+const (
+	requestUrl        = "/apis/integreatly.org/v1alpha1"
+	openShiftProvider = "openshift"
+	externalProvider  = "aws"
+)
+
+func getPostgres(installType string, installationName string) []string {
+	// Common to all install types including managed api
+	commonPostgresToCheck := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScalePostgresPrefix, installationName),
+		fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installationName),
+		fmt.Sprintf("%s%s", constants.RHSSOUserProstgresPrefix, installationName),
+	}
+
+	// Applicable to install types used in 2.X
+	rhmi2PostgresToCheck := []string{
+		fmt.Sprintf("%s%s", constants.CodeReadyPostgresPrefix, installationName),
+		fmt.Sprintf("%s%s", constants.UPSPostgresPrefix, installationName),
+		// TODO - Add check for Fuse postgres here when task for supporting external resources is done - https://issues.redhat.com/browse/INTLY-3239
+		constants.AMQAuthServicePostgres,
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonPostgresToCheck
+	} else {
+		return append(commonPostgresToCheck, rhmi2PostgresToCheck...)
+	}
+}
+
+func getRedisToCheck(installType string, installationName string) []string {
+	commonRedis := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScaleBackendRedisPrefix, installationName),
+		fmt.Sprintf("%s%s", constants.ThreeScaleSystemRedisPrefix, installationName),
+	}
+
+	managedApiRedis := []string{
+		fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, installationName),
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(commonRedis, managedApiRedis...)
+	} else {
+		return commonRedis
+	}
+}
+
+func getBlobStorageToCheck(installType, installationName string) []string {
+	common := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScaleBlobStoragePrefix, installationName),
+	}
+
+	rhmi2 := []string{
+		fmt.Sprintf("%s%s", constants.BackupsBlobStoragePrefix, installationName),
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return common
+	}
+
+	return append(common, rhmi2...)
+}
+
+func TestCROPostgresSuccessfulState(t TestingTB, ctx *TestingContext) {
+	originalStrategy := getResourceStrategy(t, ctx)
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	postgresToCheck := getPostgres(rhmi.Spec.Type, rhmi.Name)
+
+	for _, postgresName := range postgresToCheck {
+		// AMQAuthService postgres is always in cluster
+		strategy := originalStrategy
+		if postgresName == constants.AMQAuthServicePostgres {
+			strategy = openShiftProvider
+		}
+
+		postgres := &crov1.Postgres{}
+		err := getResourceAndUnMarshalJsonToResource(ctx, "postgres", postgresName, postgres)
+
+		if err != nil {
+			t.Errorf("Failed to retrieve postgres custom resource: %s", err)
+			continue
+		}
+
+		if postgres.Status.Phase != croTypes.PhaseComplete && postgres.Status.Strategy != strategy {
+			t.Errorf("%s Postgres not ready with phase: %s, message: %s, provider, %s", postgresName, postgres.Status.Phase, postgres.Status.Message, postgres.Status.Provider)
+		}
+	}
+}
+
+func TestCRORedisSuccessfulState(t TestingTB, ctx *TestingContext) {
+	strategy := getResourceStrategy(t, ctx)
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	redisToCheck := getRedisToCheck(rhmi.Spec.Type, rhmi.Name)
+
+	for _, redisName := range redisToCheck {
+		redis := &crov1.Redis{}
+		err := getResourceAndUnMarshalJsonToResource(ctx, "redis", redisName, redis)
+
+		if err != nil {
+			t.Errorf("Failed to retrieve redis custom resource: %s", err)
+			continue
+		}
+
+		if redis.Status.Phase != croTypes.PhaseComplete && redis.Status.Strategy != strategy {
+			t.Errorf("%s redis not ready with phase: %s, message: %s, provider, %s", redisName, redis.Status.Phase, redis.Status.Message, redis.Status.Provider)
+		}
+	}
+}
+
+func TestCROBlobStorageSuccessfulState(t TestingTB, ctx *TestingContext) {
+	strategy := getResourceStrategy(t, ctx)
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	blobStorageToCheck := getBlobStorageToCheck(rhmi.Spec.Type, rhmi.Name)
+
+	for _, blobStorageName := range blobStorageToCheck {
+		blobStorage := &crov1.BlobStorage{}
+		err := getResourceAndUnMarshalJsonToResource(ctx, "blobstorages", blobStorageName, blobStorage)
+
+		if err != nil {
+			t.Errorf("Failed to retrieve blobstorage custom resource: %s", err)
+			continue
+		}
+
+		if blobStorage.Status.Phase != croTypes.PhaseComplete && blobStorage.Status.Strategy != strategy {
+			t.Errorf("%s blob storage not ready with phase: %s, message: %s, provider, %s", blobStorageName, blobStorage.Status.Phase, blobStorage.Status.Message, blobStorage.Status.Provider)
+		}
+	}
+}
+
+// Function to get a custom resource and unmarshal the json to a resource type
+func getResourceAndUnMarshalJsonToResource(ctx *TestingContext, resource string, resourceName string, resourceType interface{}) error {
+	requestBody, err := getCustomResourceJson(ctx, resource, resourceName)
+
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(requestBody, resourceType)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Function to get a custom resource json without needing to depend on operator-sdk
+func getCustomResourceJson(ctx *TestingContext, resource string, resourceName string) ([]byte, error) {
+	request := ctx.ExtensionClient.RESTClient().Get().Resource(resource).Name(resourceName).Namespace(RHMIOperatorNamespace).RequestURI(requestUrl).Do(context.TODO())
+	requestBody, err := request.Raw()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return requestBody, nil
+}
+
+// Get resource provision strategy
+func getResourceStrategy(t TestingTB, ctx *TestingContext) string {
+	isClusterStorage, err := isClusterStorage(ctx)
+	if err != nil {
+		t.Fatal("error getting isClusterStorage:", err)
+	}
+
+	if !isClusterStorage {
+		return externalProvider
+	}
+
+	return openShiftProvider
+}

--- a/test/common/dashboards_data.go
+++ b/test/common/dashboards_data.go
@@ -1,0 +1,377 @@
+package common
+
+import (
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type dashboardSearchResponse struct {
+	Title string `json:"title"`
+	UID   string `json:"uid"`
+}
+
+type targetDefinition struct {
+	Expression string `json:"expr"`
+}
+
+type panelDefinition struct {
+	Datasource string             `json:"datasource"`
+	Targets    []targetDefinition `json:"targets"`
+}
+
+type dashboardDefinition struct {
+	Panels []panelDefinition `json:"panels"`
+}
+
+type dashboardDetailResponse struct {
+	Dashboard dashboardDefinition `json:"dashboard"`
+}
+
+type prometheusQueryResult struct {
+	Metric map[string]interface{} `json:"metric"`
+	Value  []interface{}          `json:"value"`
+}
+
+type prometheusQueryData struct {
+	Result []prometheusQueryResult `json:"result"`
+}
+
+type prometheusQueryResponse struct {
+	Status string              `json:"status"`
+	Data   prometheusQueryData `json:"data"`
+}
+
+var (
+	commonExpectedServices = []string{
+		"3scale-admin-ui",
+		"3scale-developer-console-ui",
+		"rhsso-ui",
+		"rhssouser-ui",
+		"3scale-system-admin-ui",
+	}
+	rhmi2ExpectedServices = []string{
+		"apicurito-ui",
+		"codeready-ui",
+		"amq-service-broker",
+		"webapp-ui",
+		"syndesis-ui",
+		"ups-ui",
+	}
+	dashboardsNames = []string{
+		"Endpoints Summary",
+		"Endpoints Detailed",
+		"Endpoints Report",
+		"Resource Usage By Pod",
+		"Resource Usage for Cluster",
+		"Resource Usage By Namespace",
+	}
+)
+
+// TestDashboardsData verifies that all dashboards are installed and all the graphs are filled with data
+func TestDashboardsData(t TestingTB, ctx *TestingContext) {
+	// Get grafana pod ip to curl
+	monitoringGrafanaPods := getGrafanaPods(t, ctx, MonitoringOperatorNamespace)
+	grafanaPodIP := monitoringGrafanaPods.Items[0].Status.PodIP
+
+	// Pod and container name to perform curls from
+	curlContainerName := "prometheus"
+	prometheusPodName, err := getMonitoringAppPodName("prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to get prometheus pod name", err)
+	}
+
+	// retry the tests every minute for up to 10 minutes
+	monitoringTimeout := 10 * time.Minute
+	monitoringRetryInterval := 1 * time.Minute
+	err = wait.PollImmediate(monitoringRetryInterval, monitoringTimeout, func() (done bool, err error) {
+		expressions, err := getDashboardExpressions(grafanaPodIP, prometheusPodName, curlContainerName, prometheusPodName, ctx, t)
+		if err != nil {
+			return false, fmt.Errorf("failed to get dashboard expressions: %w", err)
+		}
+
+		queryOutputs, err := queryPrometheusMany(expressions, prometheusPodName, ctx)
+		if err != nil {
+			return false, fmt.Errorf("failed to query prometheus many: %w", err)
+		}
+
+		var failedQueries []string
+
+		for i, queryOutput := range queryOutputs {
+			_, err := getPrometheusQueryResult(queryOutput)
+			if err != nil {
+				failedQueries = append(failedQueries, expressions[i])
+			}
+		}
+
+		failed := false
+
+		for _, failedQuery := range failedQueries {
+			// not all containers define resource requests and limits -> expected failure
+			if strings.Contains(failedQuery, "kube_pod_container_resource_requests") ||
+				strings.Contains(failedQuery, "kube_pod_container_resource_limits") {
+				continue
+			}
+
+			// following query might fail, but dashboards are still visible -> ignoring
+			if strings.Contains(failedQuery, "probe_ssl_earliest_cert_expiry") {
+				continue
+			}
+
+			// completed pods don't use resources -> expected failure
+			matched, _ := regexp.Match(`pod=~'.*(deploy|hook-pre|hook-post|build|pv-backup)*'`, []byte(failedQuery))
+			if matched {
+				continue
+			}
+
+			t.Log("failed query:", failedQuery)
+			failed = true
+		}
+
+		if failed {
+			t.Log("waiting 1 minute before retrying")
+		}
+
+		return !failed, nil
+	})
+	if err != nil {
+		t.Fatalf("failed queries: %s", err)
+	}
+}
+
+func getDashboardExpressions(grafanaPodIp string, curlPodName string, curlContainerName string, prometheusPodName string, ctx *TestingContext, t TestingTB) ([]string, error) {
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	expectedServices := getExpectedServices(rhmi.Spec.Type)
+
+	rhmiNamespaces, err := getRHMINamespaces(prometheusPodName, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RHMI namespaces: %w", err)
+	}
+
+	rhmiPods, err := getRHMIPods(rhmiNamespaces, prometheusPodName, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RHMI pods: %w", err)
+	}
+
+	// use map as a set, so that same expressions are not queried more than once
+	expressions := make(map[string]struct{})
+
+	for _, dashboardName := range dashboardsNames {
+		panels, err := getDashboardPanels(dashboardName, grafanaPodIp, curlPodName, curlContainerName, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dashboard panels: %w", err)
+		}
+
+		for _, panel := range panels {
+			if panel.Datasource == "Prometheus" {
+				for _, target := range panel.Targets {
+					// "1" has no special meaning there, it is used just to replace variables with some allowed value
+					expression := strings.ReplaceAll(target.Expression, "$__range_s", "1")
+
+					// "1d" has no special meaning there, it is used just to replace variables with some allowed value
+					expression = strings.ReplaceAll(expression, "$__range", "1d")
+
+					switch {
+					case strings.Contains(expression, "$services"):
+						for _, service := range expectedServices {
+							finalExpression := strings.ReplaceAll(expression, "$services", service)
+							expressions[finalExpression] = struct{}{}
+						}
+					case strings.Contains(expression, "$namespace"):
+						for _, namespace := range rhmiNamespaces {
+							namespaceExpression := strings.ReplaceAll(expression, "$namespace", namespace)
+
+							for _, pod := range rhmiPods[namespace] {
+								finalExpression := strings.ReplaceAll(namespaceExpression, "$pod", pod)
+								expressions[finalExpression] = struct{}{}
+							}
+						}
+					default:
+						expressions[expression] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	var expressionsSlice []string
+	for expression := range expressions {
+		expressionsSlice = append(expressionsSlice, expression)
+	}
+
+	return expressionsSlice, nil
+}
+
+func getExpectedServices(installType string) []string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonExpectedServices
+	} else {
+		return append(commonExpectedServices, rhmi2ExpectedServices...)
+	}
+}
+
+func getRHMIPods(namespaces []string, prometheusPodName string, ctx *TestingContext) (map[string][]string, error) {
+	pods := make(map[string][]string)
+
+	var queries []string
+
+	for _, namespace := range namespaces {
+		queries = append(queries, "kube_pod_info{namespace=~'"+namespace+"'}")
+	}
+
+	queryOutputs, err := queryPrometheusMany(queries, prometheusPodName, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, queryOutput := range queryOutputs {
+		queryResult, err := getPrometheusQueryResult(queryOutput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query prometheus: %w", err)
+		}
+
+		for _, result := range queryResult {
+			pods[namespaces[i]] = append(pods[namespaces[i]], result.Metric["pod"].(string))
+		}
+	}
+
+	return pods, nil
+}
+
+func getRHMINamespaces(prometheusPodName string, ctx *TestingContext) ([]string, error) {
+	queryResult, err := queryPrometheus("kube_namespace_labels{label_monitoring_key='middleware'}", prometheusPodName, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query prometheus: %w", err)
+	}
+
+	var namespaces []string
+
+	for _, result := range queryResult {
+		namespaces = append(namespaces, result.Metric["namespace"].(string))
+	}
+
+	return namespaces, nil
+}
+
+func getDashboardPanels(dashboardName string, grafanaPodIp string, curlPodName string, curlContainerName string, ctx *TestingContext) ([]panelDefinition, error) {
+	query := url.QueryEscape(dashboardName)
+	searchOutput, err := curlGrafana(grafanaPodIp, fmt.Sprintf("/api/search?query=%s", query), curlPodName, curlContainerName, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to curl grafana search: %w, dashboard name: %s, grafanaPodIp: %s, curlPodName: %s, curlContainerName: %s", err, dashboardName, grafanaPodIp, curlPodName, curlContainerName)
+	}
+
+	var dashboardSearch []dashboardSearchResponse
+	err = json.Unmarshal([]byte(searchOutput), &dashboardSearch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall json: %w", err)
+	}
+
+	if len(dashboardSearch) != 1 {
+		return nil, fmt.Errorf(dashboardName + " dashboard not found")
+	}
+
+	dashboardOutput, err := curlGrafana(grafanaPodIp, fmt.Sprintf("/api/dashboards/uid/%s", dashboardSearch[0].UID), curlPodName, curlContainerName, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to curl grafana dashboard: %w, grafanaPodIp: %s, curlPodName: %s, curlContainerName: %s, dashboard uuid: %s", err, grafanaPodIp, curlPodName, curlContainerName, dashboardSearch[0].UID)
+	}
+
+	var dashboardDetail dashboardDetailResponse
+	err = json.Unmarshal([]byte(dashboardOutput), &dashboardDetail)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall json: %w", err)
+	}
+
+	return dashboardDetail.Dashboard.Panels, nil
+}
+
+func getMonitoringAppPodName(app string, ctx *TestingContext) (string, error) {
+	pods := &corev1.PodList{}
+	opts := []k8sclient.ListOption{
+		k8sclient.InNamespace(MonitoringOperatorNamespace),
+		k8sclient.MatchingLabels{"app": app},
+	}
+
+	err := ctx.Client.List(goctx.TODO(), pods, opts...)
+	if err != nil {
+		return "", fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	if len(pods.Items) < 1 {
+		return "", fmt.Errorf("grafana pod not found for app %s", app)
+	}
+
+	return pods.Items[0].ObjectMeta.Name, nil
+}
+
+func curlGrafana(grafanaPodIp string, path string, curlPodName string, curlContainerName string, ctx *TestingContext) (string, error) {
+	return execToPod(fmt.Sprintf("curl %s:3000", grafanaPodIp)+path,
+		curlPodName,
+		MonitoringOperatorNamespace,
+		curlContainerName, ctx)
+}
+
+func queryPrometheus(query string, podName string, ctx *TestingContext) ([]prometheusQueryResult, error) {
+	queryOutput, err := execToPod("curl localhost:9090/api/v1/query?query="+url.QueryEscape(query),
+		podName,
+		MonitoringOperatorNamespace,
+		"prometheus", ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exec to prometheus pod: %w", err)
+	}
+
+	return getPrometheusQueryResult(queryOutput)
+}
+
+func queryPrometheusMany(queries []string, podName string, ctx *TestingContext) ([]string, error) {
+	command := ""
+
+	for _, query := range queries {
+		command += "curl localhost:9090/api/v1/query?query=" + url.QueryEscape(query) + ";"
+	}
+
+	output, err := execToPod(command,
+		podName,
+		MonitoringOperatorNamespace,
+		"prometheus", ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exec to prometheus pod: %w", err)
+	}
+
+	output = strings.ReplaceAll(output, "}{", "}\n{")
+	queryOutputs := strings.Split(output, "\n")
+
+	return queryOutputs, nil
+}
+
+func getPrometheusQueryResult(output string) ([]prometheusQueryResult, error) {
+	var queryResponse prometheusQueryResponse
+	err := json.Unmarshal([]byte(output), &queryResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall json: %w", err)
+	}
+
+	if queryResponse.Status != "success" {
+		return nil, fmt.Errorf("response status: %s", queryResponse.Status)
+	}
+
+	if len(queryResponse.Data.Result) == 0 {
+		return nil, fmt.Errorf("no result")
+	}
+
+	return queryResponse.Data.Result, nil
+}

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -1,0 +1,242 @@
+package common
+
+import (
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type dashboardsTestRule struct {
+	Type  string `json:"type"`
+	Title string `json:"title"`
+}
+
+// Common to all install types including managed api
+var commonExpectedDashboards = []dashboardsTestRule{
+	{
+		Title: "Endpoints Detailed",
+	},
+	{
+		Title: "Endpoints Report",
+	},
+	{
+		Title: "Endpoints Summary",
+	},
+	{
+		Title: "Keycloak",
+	},
+	{
+		Title: "Resource Usage By Namespace",
+	},
+	{
+		Title: "Resource Usage By Pod",
+	},
+	{
+		Title: "Resource Usage for Cluster",
+	},
+	{
+		Title: "Critical SLO summary",
+	},
+}
+
+// Applicable to install types used in 2.X
+var rhmi2ExpectedDashboards = []dashboardsTestRule{
+	{
+		Title: "Syndesis - Infra - API",
+	},
+	{
+		Title: "Syndesis - Infra - Home",
+	},
+	{
+		Title: "Syndesis - Infra - JVM",
+	},
+	{
+		Title: "Syndesis - Integrations - Camel",
+	},
+	{
+		Title: "Syndesis - Integrations - Home",
+	},
+	{
+		Title: "Syndesis - Integrations - JVM",
+	},
+	{
+		Title: "UnifiedPush Operator",
+	},
+	{
+		Title: "UnifiedPush Server",
+	},
+	{
+		Title: "AMQ Online",
+	},
+	{
+		Title: "EnMasse Brokers",
+	},
+	{
+		Title: "EnMasse Console",
+	},
+	{
+		Title: "EnMasse Routers",
+	},
+}
+
+var customerRHOAMDashboards = []dashboardsTestRule{
+	{
+		Title: "Rate Limiting",
+	},
+}
+
+func TestIntegreatlyCustomerDashboardsExist(t TestingTB, ctx *TestingContext) {
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Pod and container to perform curls from
+	prometheusPodName, err := getMonitoringAppPodName("prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to get prometheus pod name", err)
+	}
+	curlContainerName := "prometheus"
+
+	customerMonitoringGrafanaPods := getGrafanaPods(t, ctx, CustomerGrafanaNamespace)
+
+	output, err := execToPod(fmt.Sprintf("curl %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
+		prometheusPodName,
+		MonitoringOperatorNamespace,
+		curlContainerName, ctx)
+	if err != nil {
+		t.Fatal("failed to exec to pod:", err, "pod name:", prometheusPodName, "container name:", containerName, "namespace:", MonitoringOperatorNamespace)
+	}
+
+	var grafanaApiCallOutput []dashboardsTestRule
+	err = json.Unmarshal([]byte(output), &grafanaApiCallOutput)
+	if err != nil {
+		t.Logf("failed to unmarshall json: %s", err)
+	}
+
+	if len(grafanaApiCallOutput) == 0 {
+		t.Fatal("no grafana dashboards were found : %w", grafanaApiCallOutput)
+	}
+
+	expectedDashboards := getExpectedCustomerDashboard(rhmi.Spec.Type)
+	verifyExpectedDashboards(t, expectedDashboards, removeNamespaceDashboardFolder(grafanaApiCallOutput))
+}
+
+func TestIntegreatlyMiddelewareDashboardsExist(t TestingTB, ctx *TestingContext) {
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Pod and container to perform curls from
+	prometheusPodName, err := getMonitoringAppPodName("prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to get prometheus pod name", err)
+	}
+	curlContainerName := "prometheus"
+
+	monitoringGrafanaPods := getGrafanaPods(t, ctx, MonitoringOperatorNamespace)
+
+	output, err := execToPod(fmt.Sprintf("curl %v:3000/api/search", monitoringGrafanaPods.Items[0].Status.PodIP),
+		prometheusPodName,
+		MonitoringOperatorNamespace,
+		curlContainerName, ctx)
+	if err != nil {
+		t.Fatal("failed to exec to pod:", err, "pod name:", prometheusPodName, "container name:", containerName, "namespace:", MonitoringOperatorNamespace)
+	}
+
+	var grafanaApiCallOutput []dashboardsTestRule
+	err = json.Unmarshal([]byte(output), &grafanaApiCallOutput)
+	if err != nil {
+		t.Logf("failed to unmarshall json: %s", err)
+	}
+
+	if len(grafanaApiCallOutput) == 0 {
+		t.Fatal("no grafana dashboards were found : %w", grafanaApiCallOutput)
+	}
+
+	expectedDashboards := getExpectedMiddlewareDashboard(rhmi.Spec.Type)
+	verifyExpectedDashboards(t, expectedDashboards, removeNamespaceDashboardFolder(grafanaApiCallOutput))
+
+}
+
+func verifyExpectedDashboards(t TestingTB, expectedDashboards []dashboardsTestRule, grafanaApiCallOutput []dashboardsTestRule) {
+	var expectedDashboardTitles []string
+	for _, dashboard := range expectedDashboards {
+		expectedDashboardTitles = append(expectedDashboardTitles, dashboard.Title)
+	}
+	var actualDashboardTitles []string
+	for _, dashboard := range grafanaApiCallOutput {
+		actualDashboardTitles = append(actualDashboardTitles, dashboard.Title)
+	}
+
+	dashboardDiffUnexpected := difference(actualDashboardTitles, expectedDashboardTitles)
+	dashboardDiffMissing := difference(expectedDashboardTitles, actualDashboardTitles)
+
+	if len(dashboardDiffUnexpected) > 0 {
+		t.Logf("unexpected dashboards found: %s", strings.Join(dashboardDiffUnexpected, ", "))
+	}
+
+	if len(dashboardDiffMissing) > 0 {
+		t.Logf("missing dashboards found: %s", strings.Join(dashboardDiffMissing, ", "))
+	}
+
+	if len(dashboardDiffUnexpected) > 0 || len(dashboardDiffMissing) > 0 {
+		t.Fatal("missing or too many dashboards found")
+	}
+}
+
+func getExpectedCustomerDashboard(installType string) []dashboardsTestRule {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return customerRHOAMDashboards
+	}
+	return nil
+}
+
+func getExpectedMiddlewareDashboard(installType string) []dashboardsTestRule {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonExpectedDashboards
+	} else {
+		return append(commonExpectedDashboards, rhmi2ExpectedDashboards...)
+	}
+}
+
+func getGrafanaPods(t TestingTB, ctx *TestingContext, ns string) corev1.PodList {
+	pods := &corev1.PodList{}
+	opts := []k8sclient.ListOption{
+		k8sclient.InNamespace(ns),
+		k8sclient.MatchingLabels{"app": "grafana"},
+	}
+
+	err := ctx.Client.List(goctx.TODO(), pods, opts...)
+	if err != nil {
+		t.Fatalf("failed to list pods in ns %v", ns)
+	}
+
+	if len(pods.Items) != 1 {
+		t.Fatalf("grafana pod not found in ns %v", ns)
+	}
+
+	return *pods
+}
+
+func removeNamespaceDashboardFolder(grafanaApiOutput []dashboardsTestRule) []dashboardsTestRule {
+	var actualGrafanaDashboards []dashboardsTestRule
+
+	for _, dashboard := range grafanaApiOutput {
+		if dashboard.Type != "dash-folder" {
+			actualGrafanaDashboards = append(actualGrafanaDashboards, dashboard)
+		}
+	}
+
+	return actualGrafanaDashboards
+}

--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -1,0 +1,154 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	goctx "context"
+
+	keycloakv1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	userv1 "github.com/openshift/api/user/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	usernameNoEmail   = "autotest-user01"
+	usernameWithEmail = "autotest-user02"
+	existingEmail     = "autotest-nondefault-user02@hotmail.com"
+)
+
+// TestDefaultUserEmail verifies that a user syncronized from the IDP have a
+// default email adress if no email is present from the IDP.
+//
+// Verify that the email address is generated as <username>@rhmi.io
+func TestDefaultUserEmail(t TestingTB, ctx *TestingContext) {
+	err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts)
+	if err != nil {
+		t.Fatalf("Error occurred creating testing IDP: %v", err)
+	}
+
+	// Create user with no email
+	// the default email for this user will be <user name>@rhmi.io
+	userNoEmail, identityNoEmail, err := createUserTestingIDP(ctx, usernameNoEmail, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error creating User: %v", err)
+	}
+	// Clean up the user resource
+	defer deleteUser(ctx, userNoEmail, identityNoEmail)
+
+	// Create user with email
+	// different that the default generated email
+	userWithEmail, identityWithEmail, err := createUserTestingIDP(ctx, usernameWithEmail, func(identity *userv1.Identity) {
+		identity.Extra = map[string]string{
+			"email": existingEmail,
+		}
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating User: %v", err)
+	}
+
+	// Cleanup the user resource
+	defer deleteUser(ctx, userWithEmail, identityWithEmail)
+
+	rhssoNamespace := fmt.Sprintf("%srhsso", NamespacePrefix)
+
+	// Get the keycloak CR for each user
+	keycloakUser1, err := waitForKeycloakUser(ctx, 5*time.Minute, rhssoNamespace, usernameNoEmail)
+	if err != nil {
+		t.Fatalf("Unexpected error querying KeycloakUser %s: %v", usernameNoEmail, err)
+	}
+
+	keycloakUser2, err := waitForKeycloakUser(ctx, 5*time.Minute, rhssoNamespace, usernameWithEmail)
+	if err != nil {
+		t.Fatalf("Unexpected error querying KeycloakUser %s: %v", usernameWithEmail, err)
+		return
+	}
+
+	// Assert that the user with no email has the default generated email
+	expectedEmail := fmt.Sprintf("%s@rhmi.io", usernameNoEmail)
+	if keycloakUser1.Spec.User.Email != expectedEmail {
+		t.Errorf("Unexpected email for generated KeycloakUser: Expected %s, got %s", expectedEmail, keycloakUser1.Spec.User.Email)
+	}
+
+	// Assert that the user with email has its own email
+	if keycloakUser2.Spec.User.Email != existingEmail {
+		t.Errorf("Unexpected email for generated KeycloakUser: Expected %s, got %s", existingEmail, keycloakUser2.Spec.User.Email)
+	}
+}
+
+func createUserTestingIDP(ctx *TestingContext, userName string, mutateIdentity func(*userv1.Identity)) (*userv1.User, *userv1.Identity, error) {
+	identityName := fmt.Sprintf("%s:%s", TestingIDPRealm, userName)
+
+	identity := &userv1.Identity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: identityName,
+		},
+		ProviderName:     TestingIDPRealm,
+		ProviderUserName: userName,
+	}
+
+	if mutateIdentity != nil {
+		mutateIdentity(identity)
+	}
+
+	if err := ctx.Client.Create(goctx.TODO(), identity); err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, nil, err
+		}
+	}
+
+	var user = &userv1.User{
+		ObjectMeta: v1.ObjectMeta{
+			Name: userName,
+		},
+		Identities: []string{
+			identityName,
+		},
+	}
+
+	if err := ctx.Client.Create(goctx.TODO(), user); err != nil {
+		return nil, nil, err
+	}
+
+	return user, identity, nil
+}
+
+func deleteUser(ctx *TestingContext, user *userv1.User, identity *userv1.Identity) error {
+	// Delete the user
+	if err := ctx.Client.Delete(goctx.TODO(), user); err != nil {
+		return err
+	}
+
+	// Delete the identity
+	return ctx.Client.Delete(goctx.TODO(), identity)
+}
+
+func waitForKeycloakUser(ctx *TestingContext, timeout time.Duration, namespace, userName string) (*keycloakv1.KeycloakUser, error) {
+	began := time.Now()
+
+	for {
+		// If it timed out, return an error
+		if time.Now().After(began.Add(timeout)) {
+			return nil, fmt.Errorf("Timeout after %v", timeout)
+		}
+
+		// Get the list of users in the RHSSO namespace
+		list := &keycloakv1.KeycloakUserList{}
+		err := ctx.Client.List(goctx.TODO(), list, k8sclient.InNamespace(namespace))
+
+		// If an error occurred, return the error
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the matching user in the user list and send it if it's
+		// found
+		for _, keycloakUser := range list.Items {
+			if keycloakUser.Spec.User.UserName == userName {
+				return &keycloakUser, nil
+			}
+		}
+	}
+}

--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -1,0 +1,429 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	appsv1 "github.com/openshift/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	rhmi2DeploymentsList = []string{
+		"aMQOnlineOperatorDeployment",
+		"codeReadyOperatorDeployment",
+		"codereadyWorkspacesDeployment",
+		"fuseOperatorDeployment",
+		"solutionExplorerOperatorDeployment",
+		"upsOperatorDeployment",
+		"upsDeployment",
+	}
+	commonApiDeploymentsList = []string{
+		"threeScaleDeployment",
+		"cloudResourceOperatorDeployment",
+		"monitoringOperatorDeployment",
+		"rhssoOperatorDeployment",
+		"rhssoUserOperatorDeployment",
+	}
+	managedApiDeploymentsList = []string{
+		"marin3rOperatorDeployment",
+		"marin3rDeployment",
+	}
+)
+
+func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1.RHMI) Namespace {
+	threescaleConfig := config.NewThreeScale(map[string]string{})
+	replicas := threescaleConfig.GetReplicasConfig(inst)
+	deployment := map[string]Namespace{
+		"threeScaleDeployment": Namespace{
+			Name: ThreeScaleOperatorNamespace,
+			Products: []Product{
+				{Name: "3scale-operator", ExpectedReplicas: 1},
+			},
+		},
+		"aMQOnlineOperatorDeployment": Namespace{
+			Name: AMQOnlineOperatorNamespace,
+			Products: []Product{
+				{Name: "address-space-controller", ExpectedReplicas: 1},
+				{Name: "console", ExpectedReplicas: 1},
+				{Name: "enmasse-operator", ExpectedReplicas: 1},
+				{Name: "none-authservice", ExpectedReplicas: 1},
+				{Name: "standard-authservice", ExpectedReplicas: 1},
+			},
+		},
+		"cloudResourceOperatorDeployment": Namespace{
+			Name: CloudResourceOperatorNamespace,
+			Products: []Product{
+				{Name: "cloud-resource-operator", ExpectedReplicas: 1},
+			},
+		},
+		"codeReadyOperatorDeployment": Namespace{
+			Name: CodeReadyOperatorNamespace,
+			Products: []Product{
+				{Name: "codeready-operator", ExpectedReplicas: 1},
+			},
+		},
+		"codereadyWorkspacesDeployment": Namespace{
+			Name: NamespacePrefix + "codeready-workspaces",
+			Products: []Product{
+				{Name: "codeready", ExpectedReplicas: 1},
+				{Name: "devfile-registry", ExpectedReplicas: 1},
+				{Name: "plugin-registry", ExpectedReplicas: 1},
+			},
+		},
+		"fuseOperatorDeployment": Namespace{
+			Name: FuseOperatorNamespace,
+			Products: []Product{
+				{Name: "syndesis-operator", ExpectedReplicas: 1},
+			},
+		},
+		"monitoringOperatorDeployment": Namespace{
+			Name: MonitoringOperatorNamespace,
+			Products: []Product{
+				{Name: "application-monitoring-operator", ExpectedReplicas: 1},
+				{Name: "grafana-deployment", ExpectedReplicas: 1},
+				{Name: "grafana-operator", ExpectedReplicas: 1},
+				{Name: "prometheus-operator", ExpectedReplicas: 1},
+			},
+		},
+		"rhmiOperatorDeploymentForRhmi2": Namespace{
+			Name: RHMIOperatorNamespace,
+			Products: []Product{
+				{Name: "standard-authservice-postgresql", ExpectedReplicas: 1},
+			},
+		},
+		"rhmiOperatorDeploymentForManagedApi": Namespace{
+			Name:     RHMIOperatorNamespace,
+			Products: []Product{},
+		},
+		"rhssoOperatorDeployment": Namespace{
+			Name: RHSSOOperatorNamespace,
+			Products: []Product{
+				{Name: "keycloak-operator", ExpectedReplicas: 1},
+			},
+		},
+		"solutionExplorerOperatorDeployment": Namespace{
+			Name: SolutionExplorerOperatorNamespace,
+			Products: []Product{
+				{Name: "tutorial-web-app-operator", ExpectedReplicas: 1},
+			},
+		},
+		"upsOperatorDeployment": Namespace{
+			Name: UPSOperatorNamespace,
+			Products: []Product{
+				{Name: "unifiedpush-operator", ExpectedReplicas: 1},
+			},
+		},
+		"upsDeployment": Namespace{
+			Name: NamespacePrefix + "ups",
+			Products: []Product{
+				{Name: "ups", ExpectedReplicas: 1},
+			},
+		},
+		"rhssoUserOperatorDeployment": Namespace{
+			Name: RHSSOUserOperatorNamespace,
+			Products: []Product{
+				{Name: "keycloak-operator", ExpectedReplicas: 1},
+			},
+		},
+		"marin3rOperatorDeployment": Namespace{
+			Name: Marin3rOperatorNamespace,
+			Products: []Product{
+				{Name: "marin3r-operator", ExpectedReplicas: 1},
+			},
+		},
+		"marin3rDeployment": Namespace{
+			Name: Marin3rProductNamespace,
+			Products: []Product{
+				{Name: "marin3r-instance", ExpectedReplicas: 1},
+				{Name: "prom-statsd-exporter", ExpectedReplicas: 1},
+				{Name: "ratelimit", ExpectedReplicas: 3},
+			},
+		},
+		"threeScaleDeploymentConfig": Namespace{
+			Name: NamespacePrefix + "3scale",
+			Products: []Product{
+				{Name: "apicast-production", ExpectedReplicas: int32(replicas["apicastProd"])},
+				{Name: "apicast-staging", ExpectedReplicas: int32(replicas["apicastStage"])},
+				{Name: "backend-cron", ExpectedReplicas: int32(replicas["backendCron"])},
+				{Name: "backend-listener", ExpectedReplicas: int32(replicas["backendListener"])},
+				{Name: "backend-worker", ExpectedReplicas: int32(replicas["backendWorker"])},
+				{Name: "system-app", ExpectedReplicas: int32(replicas["systemApp"])},
+				{Name: "system-memcache", ExpectedReplicas: 1},
+				{Name: "system-sidekiq", ExpectedReplicas: int32(replicas["systemSidekiq"])},
+				{Name: "system-sphinx", ExpectedReplicas: 1},
+				{Name: "zync", ExpectedReplicas: 1},
+				{Name: "zync-database", ExpectedReplicas: int32(replicas["zyncDatabase"])},
+				{Name: "zync-que", ExpectedReplicas: int32(replicas["zyncQue"])},
+			},
+		},
+		"fuseDeploymentConfig": Namespace{
+			Name: NamespacePrefix + "fuse",
+			Products: []Product{
+				{Name: "syndesis-meta", ExpectedReplicas: 1},
+				{Name: "syndesis-oauthproxy", ExpectedReplicas: 1},
+				{Name: "syndesis-prometheus", ExpectedReplicas: 1},
+				{Name: "syndesis-server", ExpectedReplicas: 1},
+				{Name: "syndesis-ui", ExpectedReplicas: 1},
+				{Name: "broker-amq", ExpectedReplicas: 1},
+			},
+		},
+		"solutionExplorerDeploymentConfig": Namespace{
+			Name: NamespacePrefix + "solution-explorer",
+			Products: []Product{
+				{Name: "tutorial-web-app", ExpectedReplicas: 1},
+			},
+		},
+	}
+
+	return deployment[deploymentName]
+}
+
+func getClusterStorageDeployments(installationName string, installType string) []Namespace {
+
+	rhmi2ClusterStorageDeployments := []Namespace{
+		{
+			Name: NamespacePrefix + "operator",
+			Products: []Product{
+				{Name: constants.CodeReadyPostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.ThreeScaleBackendRedisPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.ThreeScalePostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.ThreeScaleSystemRedisPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.UPSPostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.RHSSOPostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.RHSSOUserProstgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.AMQAuthServicePostgres, ExpectedReplicas: 1},
+			},
+		},
+	}
+	managedApiClusterStorageDeployments := []Namespace{
+		{
+			Name: NamespacePrefix + "operator",
+			Products: []Product{
+				{Name: constants.ThreeScaleBackendRedisPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.ThreeScalePostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.ThreeScaleSystemRedisPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.RHSSOPostgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.RHSSOUserProstgresPrefix + installationName, ExpectedReplicas: 1},
+				{Name: constants.RateLimitRedisPrefix + installationName, ExpectedReplicas: 1},
+			},
+		},
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiClusterStorageDeployments
+	} else {
+		return rhmi2ClusterStorageDeployments
+	}
+}
+
+func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	deployments := getDeployments(rhmi)
+	clusterStorageDeployments := getClusterStorageDeployments(rhmi.Name, rhmi.Spec.Type)
+
+	isClusterStorage, err := isClusterStorage(ctx)
+	if err != nil {
+		t.Fatal("error getting isClusterStorage:", err)
+	}
+
+	// If the cluster is using in cluster storage instead of AWS resources
+	// These deployments will also need to be checked
+	if isClusterStorage {
+		for _, d := range clusterStorageDeployments {
+			deployments = append(deployments, d)
+		}
+	}
+
+	for _, namespace := range deployments {
+		for _, product := range namespace.Products {
+
+			deployment, err := ctx.KubeClient.AppsV1().Deployments(namespace.Name).Get(context.TODO(), product.Name, v1.GetOptions{})
+			if err != nil {
+				// Fail the test without failing immideatlly
+				t.Errorf("Failed to get Deployment %s in namespace %s with error: %s", product.Name, namespace.Name, err)
+				continue
+			}
+
+			if deployment.Status.Replicas < product.ExpectedReplicas {
+				t.Errorf("Deployment %s in namespace %s doesn't match the number of expected replicas. Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					deployment.Status.Replicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+
+			// Verify that the expected replicas are also available, means they are up and running and consumable by users
+			if deployment.Status.AvailableReplicas < product.ExpectedReplicas {
+				t.Errorf("Deployment %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					deployment.Status.AvailableReplicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+		}
+	}
+}
+
+func getDeployments(inst *integreatlyv1alpha1.RHMI) []Namespace {
+	var rhmi2Deployments []Namespace
+	var commonApiDeployments []Namespace
+	var managedApiDeployments []Namespace
+
+	for _, deployment := range rhmi2DeploymentsList {
+		rhmi2Deployments = append(rhmi2Deployments, getDeploymentConfiguration(deployment, inst))
+	}
+	for _, deployment := range commonApiDeploymentsList {
+		commonApiDeployments = append(commonApiDeployments, getDeploymentConfiguration(deployment, inst))
+	}
+	for _, deployment := range managedApiDeploymentsList {
+		managedApiDeployments = append(managedApiDeployments, getDeploymentConfiguration(deployment, inst))
+	}
+
+	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(append(commonApiDeployments, []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForManagedApi", inst)}...), managedApiDeployments...)
+	} else {
+		return append(append(commonApiDeployments, rhmi2Deployments...), []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForRhmi2", inst)}...)
+	}
+}
+
+func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	deploymentConfigs := getDeploymentConfigs(rhmi)
+
+	for _, namespace := range deploymentConfigs {
+		for _, product := range namespace.Products {
+
+			deploymentConfig := &appsv1.DeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      product.Name,
+					Namespace: namespace.Name,
+				},
+			}
+			err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: product.Name, Namespace: namespace.Name}, deploymentConfig)
+			if err != nil {
+				t.Errorf("Failed to get DeploymentConfig %s in namespace %s with error: %s", product.Name, namespace.Name, err)
+				continue
+			}
+
+			if deploymentConfig.Status.Replicas < product.ExpectedReplicas {
+				t.Errorf("DeploymentConfig %s in namespace %s doesn't match the number of expected replicas. Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					deploymentConfig.Status.Replicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+
+			if deploymentConfig.Status.AvailableReplicas < product.ExpectedReplicas {
+				t.Errorf("DeploymentConfig %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					deploymentConfig.Status.AvailableReplicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+		}
+	}
+}
+
+func getDeploymentConfigs(inst *integreatlyv1alpha1.RHMI) []Namespace {
+	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return []Namespace{
+			getDeploymentConfiguration("threeScaleDeploymentConfig", inst),
+		}
+	}
+	return []Namespace{
+		getDeploymentConfiguration("threeScaleDeploymentConfig", inst),
+		getDeploymentConfiguration("fuseDeploymentConfig", inst),
+		getDeploymentConfiguration("solutionExplorerDeploymentConfig", inst),
+	}
+}
+
+func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	var rhssoExpectedReplicas int32 = 2
+	var rhssoUserExpectedReplicas int32 = 3
+	if resources.RunningInProw(rhmi) {
+		rhssoExpectedReplicas = 1
+		rhssoUserExpectedReplicas = 1
+	}
+	statefulSets := []Namespace{
+		{
+			Name: MonitoringOperatorNamespace,
+			Products: []Product{
+				Product{Name: "alertmanager-application-monitoring", ExpectedReplicas: 1},
+				Product{Name: "prometheus-application-monitoring", ExpectedReplicas: 1},
+			},
+		},
+		{
+			Name: NamespacePrefix + "rhsso",
+			Products: []Product{
+				Product{Name: "keycloak", ExpectedReplicas: rhssoExpectedReplicas},
+			},
+		},
+		{
+			Name: NamespacePrefix + "user-sso",
+			Products: []Product{
+				Product{Name: "keycloak", ExpectedReplicas: rhssoUserExpectedReplicas},
+			},
+		},
+	}
+
+	for _, namespace := range statefulSets {
+		for _, product := range namespace.Products {
+			statefulSet, err := ctx.KubeClient.AppsV1().StatefulSets(namespace.Name).Get(context.TODO(), product.Name, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("Failed to get StatefulSet %s in namespace %s with error: %s", product.Name, namespace.Name, err)
+				continue
+			}
+
+			if statefulSet.Status.Replicas < product.ExpectedReplicas {
+				t.Errorf("StatefulSet %s in namespace %s doesn't match the number of expected replicas. Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					statefulSet.Status.Replicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+
+			// Verify the number of ReadyReplicas because the SatefulSet doesn't have the concept of AvailableReplicas
+			if statefulSet.Status.ReadyReplicas < product.ExpectedReplicas {
+				t.Errorf("StatefulSet %s in namespace %s doesn't match the number of expected ready replicas. Ready Replicas: %v / Expected Replicas: %v",
+					product.Name,
+					namespace.Name,
+					statefulSet.Status.ReadyReplicas,
+					product.ExpectedReplicas,
+				)
+				continue
+			}
+		}
+	}
+}

--- a/test/common/fuse_crudl.go
+++ b/test/common/fuse_crudl.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+)
+
+var (
+	fuseLoginUser     = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+	fuseLoginPassword = DefaultPassword
+)
+
+func loginOpenshift(t TestingTB, ctx *TestingContext, masterUrl, username, password, namespacePrefix string) error {
+	authUrl := fmt.Sprintf("%s/auth/login", masterUrl)
+
+	if err := resources.DoAuthOpenshiftUser(authUrl, username, password, ctx.HttpClient, "testing-idp", t); err != nil {
+		return err
+	}
+
+	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterUrl)
+	if err := resources.OpenshiftUserReconcileCheck(openshiftClient, ctx.Client, namespacePrefix, username); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Tests that a user in group rhmi-developers can log into fuse and
+// create an integration
+func TestFuseCrudlPermissions(t TestingTB, ctx *TestingContext) {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	masterURL := rhmi.Spec.MasterURL
+
+	// Get the fuse host url from the rhmi status
+	fuseHost := rhmi.Status.Stages[v1alpha1.ProductsStage].Products[v1alpha1.ProductFuse].Host
+
+	err = loginOpenshift(t, ctx, masterURL, fuseLoginUser, fuseLoginPassword, rhmi.Spec.NamespacePrefix)
+	if err != nil {
+		t.Fatalf("error logging into openshift: %v", err)
+	}
+
+	// Get a client that authenticated to fuse via oauth
+	authenticatedFuseClient, err := resources.ProxyOAuth(ctx.HttpClient, fuseHost, fuseLoginUser, DefaultPassword)
+	if err != nil {
+		t.Fatalf("error authenticating with fuse: %v", err)
+	}
+
+	fuseApi := resources.NewFuseApiClient(fuseHost, authenticatedFuseClient)
+
+	err = fuseApi.Ping()
+	if err != nil {
+		t.Fatalf("error pinging fuse: %v", err)
+	}
+
+	// Make sure there are no integrations present
+	count, err := fuseApi.CountIntegrations()
+	if err != nil {
+		t.Fatalf("error counting integrations: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no fuse integrations, but %v found", count)
+	}
+
+	// Create one integration
+	integrationId, err := fuseApi.CreateIntegration(resources.FuseIntegrationPayload)
+	if err != nil {
+		t.Fatalf("error creating integration: %v", err)
+	}
+
+	// Now there should be exactly one integration
+	count, err = fuseApi.CountIntegrations()
+	if err != nil {
+		t.Fatalf("error counting integrations: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 fuse integration,  but %v found", count)
+	}
+
+	// Delete the previously created integration
+	err = fuseApi.DeleteIntegration(integrationId)
+	if err != nil {
+		t.Fatalf("error deleting integration: %v", err)
+	}
+}

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -1,0 +1,198 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"strings"
+
+	v12 "github.com/openshift/api/authorization/v1"
+	v1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	grafanaCredsUsername = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+	grafanaCredsPassword = DefaultPassword
+)
+
+func TestCustomerGrafanaExternalRouteAccessible(t TestingTB, ctx *TestingContext) {
+	if os.Getenv("SKIP_FLAKES") == "true" {
+		// https://issues.redhat.com/browse/MGDAPI-555
+		t.Log("skipping 3scale SMTP test due to skip_flakes flag")
+		t.SkipNow()
+	}
+	grafanaRootHostname, err := getGrafanaRoute(ctx.Client, CustomerGrafanaNamespace)
+	if err != nil {
+		t.Fatal("failed to get grafana route", err)
+	}
+
+	testRoute(t, ctx, grafanaRootHostname)
+}
+
+func TestGrafanaExternalRouteAccessible(t TestingTB, ctx *TestingContext) {
+	grafanaRootHostname, err := getGrafanaRoute(ctx.Client, MonitoringOperatorNamespace)
+	if err != nil {
+		t.Fatal("failed to get grafana route", err)
+	}
+
+	testRoute(t, ctx, grafanaRootHostname)
+}
+
+func testRoute(t TestingTB, ctx *TestingContext, grafanaRootHostname string) {
+	// create new http client
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal("failed to create testing http client", err)
+	}
+
+	grafanaMetricsEndpoint := fmt.Sprintf("%s/metrics", grafanaRootHostname)
+
+	req, err := http.NewRequest("GET", grafanaMetricsEndpoint, nil)
+	if err != nil {
+		t.Fatal("failed to prepare test request to grafana", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal("failed to perform test request to grafana", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code on request, got=%+v", resp.StatusCode)
+	}
+}
+
+func TestGrafanaExternalRouteDashboardExist(t TestingTB, ctx *TestingContext) {
+	const (
+		serviceAccountName = "test"
+		bindingName        = "test"
+	)
+
+	//create service account - its token will be used to call grafana api
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: MonitoringOperatorNamespace,
+			Name:      serviceAccountName,
+		},
+	}
+	err := ctx.Client.Create(goctx.TODO(), serviceAccount)
+	if err != nil {
+		t.Fatal("failed to create serviceAccount", err)
+	}
+	defer ctx.Client.Delete(goctx.TODO(), serviceAccount)
+	binding := &v12.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bindingName,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind:       "ServiceAccount",
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Name:       serviceAccountName,
+				Namespace:  MonitoringOperatorNamespace,
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind:       "ClusterRole",
+			Name:       "cluster-admin",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+	}
+	err = ctx.Client.Create(goctx.TODO(), binding)
+	if err != nil {
+		t.Fatal("failed to create clusterRoleBinding", err)
+	}
+	defer ctx.Client.Delete(goctx.TODO(), binding)
+
+	grafanaRootHostname, err := getGrafanaRoute(ctx.Client, MonitoringOperatorNamespace)
+	if err != nil {
+		t.Fatal("failed to get grafana route", err)
+	}
+
+	token := ""
+	secrets, err := ctx.KubeClient.CoreV1().Secrets(MonitoringOperatorNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("failed to get secrets", err)
+	}
+	for _, secretsItem := range secrets.Items {
+		if strings.HasPrefix(secretsItem.Name, "test-token-") {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretsItem.Name,
+					Namespace: MonitoringOperatorNamespace,
+				},
+			}
+			err = ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: secretsItem.Name, Namespace: MonitoringOperatorNamespace}, secret)
+			if err != nil {
+				t.Fatal("failed to get secret", err)
+			}
+
+			if _, ok := secret.Annotations["kubernetes.io/created-by"]; !ok {
+				token = string(secret.Data["token"])
+				break
+			}
+		}
+	}
+	if token == "" {
+		t.Skip("skipping test due to flakyness on osde2e - Jira: https://issues.redhat.com/browse/INTLY-10316")
+		//t.Fatal("failed to find token for serviceAccount")
+	}
+
+	//create new http client
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal("failed to create testing http client", err)
+	}
+	//get dashboards for grafana from the external route
+	grafanaDashboardsURL := fmt.Sprintf("%s/api/search", grafanaRootHostname)
+	req, err := http.NewRequest("GET", grafanaDashboardsURL, nil)
+	if err != nil {
+		t.Fatal("failed to create request for grafana", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	dashboardResp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal("failed to perform test request to grafana", err)
+	}
+	defer dashboardResp.Body.Close()
+	//there is an existing dashboard check, so confirm a valid response structure
+	if dashboardResp.StatusCode != http.StatusOK {
+		dumpResp, _ := httputil.DumpResponse(dashboardResp, true)
+		t.Logf("dumpResp: %q", dumpResp)
+		t.Fatalf("unexpected status code on success request, got=%+v", dashboardResp)
+	}
+
+	var dashboards []interface{}
+	if err := json.NewDecoder(dashboardResp.Body).Decode(&dashboards); err != nil {
+		t.Fatal("failed to decode grafana dashboards response", err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatal("no grafana dashboards returned from grafana api")
+	}
+}
+
+func getGrafanaRoute(c client.Client, namespace string) (string, error) {
+	const (
+		routeGrafanaName = "grafana-route"
+	)
+	Context := context.TODO()
+	//get grafana openshift route
+	grafanaRoute := &v1.Route{}
+	if err := c.Get(Context, client.ObjectKey{Name: routeGrafanaName, Namespace: namespace}, grafanaRoute); err != nil {
+		return "", fmt.Errorf("failed to get grafana route: %w", err)
+	}
+	//evaluate the grafana route hostname
+	grafanaRootHostname := grafanaRoute.Spec.Host
+	if grafanaRoute.Spec.TLS != nil {
+		grafanaRootHostname = fmt.Sprintf("https://%s", grafanaRootHostname)
+	}
+	return grafanaRootHostname, nil
+}

--- a/test/common/integreatly_stages.go
+++ b/test/common/integreatly_stages.go
@@ -1,0 +1,157 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	rhmi2ExpectedStageProducts = map[string][]string{
+		"authentication": {
+			"rhsso",
+		},
+
+		"bootstrap": {},
+
+		"cloud-resources": {
+			"cloud-resources",
+		},
+
+		"monitoring": {
+			"middleware-monitoring",
+		},
+
+		"products": {
+			"fuse",
+			"rhssouser",
+			"datasync",
+			"codeready-workspaces",
+			"fuse-on-openshift",
+			"3scale",
+			"amqonline",
+			"ups",
+			"apicurito",
+		},
+
+		"solution-explorer": {
+			"solution-explorer",
+		},
+	}
+
+	managedApiExpectedStageProducts = map[string][]string{
+		"authentication": {
+			"rhsso",
+		},
+
+		"bootstrap": {},
+
+		"cloud-resources": {
+			"cloud-resources",
+		},
+
+		"monitoring": {
+			"middleware-monitoring",
+		},
+
+		"products": {
+			"rhssouser",
+			"3scale",
+			"marin3r",
+			"grafana",
+		},
+	}
+)
+
+func TestIntegreatlyStagesStatus(t TestingTB, ctx *TestingContext) {
+	err := wait.PollImmediateInfinite(time.Second*15, func() (bool, error) {
+		done := true
+
+		//get RHMI
+		rhmi, err := GetRHMI(ctx.Client, true)
+		if err != nil {
+			return false, fmt.Errorf("error getting RHMI CR: %v", err)
+		}
+
+		expectedStageProducts := getExpectedStageProducts(rhmi.Spec.Type)
+
+		//iterate stages and check their status
+		for stageName, productNames := range expectedStageProducts {
+			stage, ok := rhmi.Status.Stages[v1alpha1.StageName(stageName)]
+			if !ok {
+				t.Errorf("Error checking stage %s. Not found", stageName)
+				done = true
+				continue
+			}
+
+			if status := checkStageStatus(stage); status != "" {
+				if retryStatus(status) {
+					t.Logf("Status for stage %s in progress. Retrying...", stageName)
+					done = false
+				} else {
+					t.Errorf("Error: Stage %v failed. It's current status is %v", stage.Name, status)
+					done = true
+				}
+			}
+
+			for _, productName := range productNames {
+				product, ok := stage.Products[v1alpha1.ProductName(productName)]
+				if !ok {
+					t.Errorf("Product %s not found in stage %s", productName, stageName)
+					done = true
+					continue
+				}
+
+				if status := checkProductStatus(product); status != "" {
+					if retryStatus(status) {
+						t.Logf("Status for product %s in stage %s in progress. Retrying...", productName, stageName)
+						done = false
+					} else {
+						t.Errorf("Error: Product %s status failed. It's current status is %s", productName, status)
+						done = true
+					}
+				}
+			}
+		}
+
+		return done, nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func getExpectedStageProducts(installType string) map[string][]string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiExpectedStageProducts
+	} else {
+		return rhmi2ExpectedStageProducts
+	}
+}
+
+func checkStageStatus(stage v1alpha1.RHMIStageStatus) string {
+	return checkStatus(stage.Phase)
+}
+
+func checkProductStatus(product v1alpha1.RHMIProductStatus) string {
+	return checkStatus(product.Status)
+}
+
+// checkStatus verifies that the status is complete. If it is, returns the empty
+// string. If it's not, returns the invalid status as a string
+func checkStatus(status v1alpha1.StatusPhase) string {
+	//check if status is completed or return and error
+	if status == "completed" {
+		return ""
+	}
+
+	return string(status)
+}
+
+func retryStatus(status string) bool {
+	return status == "in progress"
+}

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -1,0 +1,178 @@
+package common
+
+import (
+	goctx "context"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clonedServiceMonitorLabelKey   = "integreatly.org/cloned-servicemonitor"
+	clonedServiceMonitorLabelValue = "true"
+	labelSelector                  = "monitoring-key=middleware"
+	roleBindingName                = "rhmi-prometheus-k8s"
+	roleRefName                    = "rhmi-prometheus-k8s"
+)
+
+func getServiceMonitorsByType(monitorsType string) []string {
+	monitors := map[string][]string{
+		"rhmi2ExpectedServiceMonitors": []string{
+			NamespacePrefix + "amq-online-enmasse-address-space-controller",
+			NamespacePrefix + "amq-online-enmasse-admin",
+			NamespacePrefix + "amq-online-enmasse-broker",
+			NamespacePrefix + "amq-online-enmasse-console",
+			NamespacePrefix + "amq-online-enmasse-iot",
+			NamespacePrefix + "amq-online-enmasse-operator-metrics",
+			NamespacePrefix + "amq-online-enmasse-router",
+			NamespacePrefix + "fuse-syndesis-infra",
+			NamespacePrefix + "fuse-syndesis-integrations",
+			NamespacePrefix + "ups-operator-unifiedpush-operator-metrics",
+			NamespacePrefix + "ups-unifiedpush",
+		},
+		"managedApiServiceMonitors": []string{
+			Marin3rProductNamespace + "-prom-statsd-exporter",
+		},
+		"commonExpectedServiceMonitors": []string{
+			NamespacePrefix + "cloud-resources-operator-cloud-resource-operator-metrics",
+			NamespacePrefix + "middleware-monitoring-operator-application-monitoring-operator-metrics",
+			NamespacePrefix + "middleware-monitoring-operator-grafana-servicemonitor",
+			NamespacePrefix + "middleware-monitoring-operator-prometheus-servicemonitor",
+			NamespacePrefix + "rhsso-keycloak-service-monitor",
+			NamespacePrefix + "user-sso-keycloak-service-monitor",
+		},
+	}
+
+	return monitors[monitorsType]
+}
+
+// TestServiceMonitorsCloneAndRolebindingsExist monitoring spec testcase
+// Verifies the list of servicemonitors that are cloned in monitoring namespace
+// Verifies the rolebindings exist
+// Verifies if there are any stale service monitors in the monitoring namespace
+func TestServiceMonitorsCloneAndRolebindingsExist(t TestingTB, ctx *TestingContext) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+	expectedServiceMonitors := getExpectedServiceMonitors(rhmi.Spec.Type)
+
+	//Get list of service monitors in the monitoring namespace
+	monSermonMap, err := getServiceMonitors(ctx, MonitoringSpecNamespace)
+	if err != nil {
+		t.Fatal("failed to list servicemonitors in monitoring namespace:", err)
+	}
+	if len(monSermonMap) == 0 {
+		t.Fatal("No servicemonitors present in monitoring namespace")
+	}
+	//Validate the servicemonitors against the list
+	for _, sm := range expectedServiceMonitors {
+		if _, ok := monSermonMap[sm]; !ok {
+			t.Fatal("Error - Servicemonitor(s) not found in monitoring namespace", sm)
+		}
+	}
+	//Check if rolebindings exists
+	for _, sm := range monSermonMap {
+		for _, namespace := range sm.Spec.NamespaceSelector.MatchNames {
+			err := checkRoleExists(ctx, roleRefName, namespace)
+			if err != nil {
+				t.Fatal("Error retrieving role: ", err, "in namespace:", namespace)
+			}
+			err = checkRoleBindingExists(ctx, roleBindingName, namespace)
+			if err != nil {
+				t.Fatal("Error retrieving rolebinding: ", err, "in namespace:", namespace)
+			}
+		}
+	}
+	//Get the namespaces
+	ls, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Fatal("failed to parse label", err)
+	}
+	opts := &k8sclient.ListOptions{
+		LabelSelector: ls,
+	}
+	namespaces := &corev1.NamespaceList{}
+	err = ctx.Client.List(goctx.TODO(), namespaces, opts)
+	if err != nil {
+		t.Fatal("failed to list namespaces", err)
+	}
+	//Get servicemonitors for each namespace and validate them
+	for _, ns := range namespaces.Items {
+		//Get list of service monitors in each name space
+		listOpts := []k8sclient.ListOption{
+			k8sclient.InNamespace(ns.Name),
+		}
+		serviceMonitors := &monitoringv1.ServiceMonitorList{}
+		err := ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
+		if err != nil {
+			t.Fatal("failed to list servicemonitors", err)
+		}
+		for _, sm := range serviceMonitors.Items {
+			key := sm.Namespace + `-` + sm.Name
+			if _, ok := monSermonMap[key]; !ok {
+				t.Fatal("Servicemonitor: ", key, "not found in monitoring namespace")
+			}
+			delete(monSermonMap, key) // Servicemonitor exists, remove it from the local map
+		}
+	}
+	// Any values left in the servicemonitors map are stale
+	if len(monSermonMap) > 0 {
+		var staleMonitors string
+		for key := range monSermonMap {
+			staleMonitors = staleMonitors + key + ","
+		}
+		t.Fatal("stale service monitors present: ", staleMonitors)
+	}
+}
+
+func getServiceMonitors(ctx *TestingContext,
+	nameSpace string) (serviceMonitorsMap map[string]*monitoringv1.ServiceMonitor, err error) {
+	//Get list of service monitors in the namespace that has
+	//label "integreatly.org/cloned-servicemonitor" set to "true"
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+		k8sclient.MatchingLabels(getClonedServiceMonitorLabel()),
+	}
+	serviceMonitors := &monitoringv1.ServiceMonitorList{}
+	err = ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
+	if err != nil {
+		return serviceMonitorsMap, err
+	}
+	serviceMonitorsMap = make(map[string]*monitoringv1.ServiceMonitor)
+	for _, sm := range serviceMonitors.Items {
+		serviceMonitorsMap[sm.Name] = sm
+	}
+	return serviceMonitorsMap, err
+}
+
+func getClonedServiceMonitorLabel() map[string]string {
+	return map[string]string{
+		clonedServiceMonitorLabelKey: clonedServiceMonitorLabelValue,
+	}
+}
+
+func checkRoleBindingExists(ctx *TestingContext, name, namespace string) (err error) {
+	rb := &rbac.RoleBinding{}
+	err = ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, rb)
+	return err
+}
+
+func checkRoleExists(ctx *TestingContext, name, namespace string) (err error) {
+	role := &rbac.Role{}
+	err = ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, role)
+	return err
+}
+
+func getExpectedServiceMonitors(installType string) []string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(getServiceMonitorsByType("commonExpectedServiceMonitors"), getServiceMonitorsByType("managedApiServiceMonitors")...)
+	} else {
+		return append(getServiceMonitorsByType("commonExpectedServiceMonitors"), getServiceMonitorsByType("rhmi2ExpectedServiceMonitors")...)
+	}
+}

--- a/test/common/namespace_created.go
+++ b/test/common/namespace_created.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	goctx "context"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func rhmi2Namespaces() []string {
+	return []string{
+		MonitoringOperatorNamespace,
+		MonitoringFederateNamespace,
+		AMQOnlineOperatorNamespace,
+		ApicuritoProductNamespace,
+		ApicuritoOperatorNamespace,
+		CloudResourceOperatorNamespace,
+		CodeReadyProductNamespace,
+		CodeReadyOperatorNamespace,
+		FuseProductNamespace,
+		FuseOperatorNamespace,
+		RHSSOUserProductOperatorNamespace,
+		RHSSOUserOperatorNamespace,
+		RHSSOProductNamespace,
+		RHSSOOperatorNamespace,
+		SolutionExplorerProductNamespace,
+		SolutionExplorerOperatorNamespace,
+		ThreeScaleProductNamespace,
+		ThreeScaleOperatorNamespace,
+		UPSProductNamespace,
+		UPSOperatorNamespace,
+	}
+}
+
+func managedApiNamespaces() []string {
+	return []string{
+		MonitoringOperatorNamespace,
+		MonitoringFederateNamespace,
+		CloudResourceOperatorNamespace,
+		RHSSOUserProductOperatorNamespace,
+		RHSSOUserOperatorNamespace,
+		RHSSOProductNamespace,
+		RHSSOOperatorNamespace,
+		ThreeScaleProductNamespace,
+		ThreeScaleOperatorNamespace,
+		Marin3rOperatorNamespace,
+		Marin3rProductNamespace,
+		CustomerGrafanaNamespace,
+	}
+}
+
+func TestNamespaceCreated(t TestingTB, ctx *TestingContext) {
+
+	namespacesCreated := getNamespaces(t, ctx)
+
+	for _, namespace := range namespacesCreated {
+		ns := &corev1.Namespace{}
+		err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: namespace}, ns)
+
+		if err != nil {
+			t.Errorf("Expected %s namespace to be created but wasn't: %s", namespace, err)
+			continue
+		}
+	}
+}
+
+func getNamespaces(t TestingTB, ctx *TestingContext) []string {
+
+	//get RHMI
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Errorf("error getting RHMI CR: %v", err)
+	}
+
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiNamespaces()
+	} else {
+		return rhmi2Namespaces()
+	}
+}

--- a/test/common/namespace_restoration.go
+++ b/test/common/namespace_restoration.go
@@ -1,0 +1,384 @@
+package common
+
+import (
+	goctx "context"
+
+	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	stageRestorationTimeOut        = 30 * time.Minute
+	stageRetryInterval             = 15 * time.Second
+	finalizerDeletionTimeout       = 2 * time.Minute
+	finalizerDeletionRetryInterval = 10 * time.Second
+)
+
+type StageDeletion struct {
+	productStageName integreatlyv1alpha1.StageName
+	namespaces       []string
+	removeFinalizers func(ctx *TestingContext) error
+}
+
+var (
+	commonStages = []StageDeletion{
+		{
+			productStageName: integreatlyv1alpha1.AuthenticationStage,
+			namespaces: []string{
+				RHSSOProductNamespace,
+				RHSSOOperatorNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return removeKeyCloakFinalizers(ctx, RHSSOProductNamespace)
+			},
+		},
+		{
+			productStageName: integreatlyv1alpha1.CloudResourcesStage,
+			namespaces: []string{
+				CloudResourceOperatorNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return nil
+			},
+		},
+		{
+			productStageName: integreatlyv1alpha1.MonitoringStage,
+			namespaces: []string{
+				MonitoringOperatorNamespace,
+				MonitoringFederateNamespace,
+				MonitoringSpecNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return removeMonitoringFinalizers(ctx, MonitoringOperatorNamespace)
+			},
+		},
+	}
+
+	rhmiSpecificStages = []StageDeletion{
+		{
+			productStageName: integreatlyv1alpha1.ProductsStage,
+			namespaces: []string{
+				AMQOnlineOperatorNamespace,
+				ApicuritoProductNamespace,
+				ApicuritoOperatorNamespace,
+				CodeReadyProductNamespace,
+				CodeReadyOperatorNamespace,
+				FuseProductNamespace,
+				FuseOperatorNamespace,
+				RHSSOUserProductOperatorNamespace,
+				RHSSOUserOperatorNamespace,
+				ThreeScaleProductNamespace,
+				ThreeScaleOperatorNamespace,
+				UPSProductNamespace,
+				UPSOperatorNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return removeKeyCloakFinalizers(ctx, RHSSOUserProductOperatorNamespace)
+			},
+		},
+		{
+			productStageName: integreatlyv1alpha1.SolutionExplorerStage,
+			namespaces: []string{
+				SolutionExplorerProductNamespace,
+				SolutionExplorerOperatorNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return nil
+			},
+		},
+	}
+
+	managedApiStages = []StageDeletion{
+		{
+			productStageName: integreatlyv1alpha1.ProductsStage,
+			namespaces: []string{
+				CustomerGrafanaNamespace,
+				Marin3rOperatorNamespace,
+				Marin3rProductNamespace,
+				RHSSOUserProductOperatorNamespace,
+				RHSSOUserOperatorNamespace,
+				ThreeScaleProductNamespace,
+				ThreeScaleOperatorNamespace,
+			},
+			removeFinalizers: func(ctx *TestingContext) error {
+				return removeKeyCloakFinalizers(ctx, RHSSOUserProductOperatorNamespace)
+			},
+		},
+	}
+)
+
+func TestNamespaceRestoration(t TestingTB, ctx *TestingContext) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, stage := range getStagesForInstallType(rhmi.Spec.Type) {
+
+		// Delete all the namespaces defined in product stage
+		for _, nameSpace := range stage.namespaces {
+			nameSpaceForDeletion := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nameSpace,
+					Namespace: nameSpace,
+				},
+			}
+
+			err := ctx.Client.Delete(goctx.TODO(), nameSpaceForDeletion)
+
+			if err != nil {
+				t.Fatalf("Error deleting %s namespace: %s", nameSpace, err)
+			}
+
+			t.Logf("Deleted %s namespace", nameSpace)
+		}
+
+		// Remove any finalizers that may be preventing stage deletion
+		err := stage.removeFinalizers(ctx)
+
+		if err != nil {
+			t.Fatalf("Failed to remove finalizers for stage %s: %s", stage.productStageName, err)
+		}
+
+		t.Logf("Success removing finalizers for %s stage", stage.productStageName)
+
+		// Wait for product stage to be in progress
+		err = waitForProductStageStatusInRHMI(t, ctx, stage.productStageName, integreatlyv1alpha1.PhaseInProgress)
+
+		if err != nil {
+			t.Fatalf("Failed to wait for %s stage to change to %s with error: %s", stage.productStageName, integreatlyv1alpha1.PhaseInProgress, err)
+		}
+
+		// Wait for product stage to complete
+		err = waitForProductStageStatusInRHMI(t, ctx, stage.productStageName, integreatlyv1alpha1.PhaseCompleted)
+
+		if err != nil {
+			t.Fatalf("Failed to wait for %s stage to change to %s with error: %s", stage.productStageName, integreatlyv1alpha1.PhaseCompleted, err)
+		}
+	}
+}
+
+// Wait for the product stage to be a specific status
+func waitForProductStageStatusInRHMI(t TestingTB, ctx *TestingContext, stage integreatlyv1alpha1.StageName, status integreatlyv1alpha1.StatusPhase) error {
+	err := wait.Poll(stageRetryInterval, stageRestorationTimeOut, func() (done bool, err error) {
+		rhmi, err := GetRHMI(ctx.Client, true)
+		if err != nil {
+			t.Logf("Got an error getting rhmi cr: %v", err)
+			return false, err
+		}
+
+		if rhmi.Status.Stages[stage].Phase != status {
+			t.Logf("Waiting for %s stage status to change to %s", stage, status)
+			return false, nil
+		}
+
+		t.Logf("%s stage status changed to %s", stage, status)
+		return true, nil
+	})
+
+	return err
+}
+
+// Remove finalizers from KeyCloak resources from a target namespace
+func removeKeyCloakFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := removeKeyCloakClientFinalizers(ctx, nameSpace)
+	if err != nil {
+		return err
+	}
+
+	err = removeKeyCloakRealmFinalizers(ctx, nameSpace)
+	if err != nil {
+		return err
+	}
+
+	err = removeKeyCloakUserFinalizers(ctx, nameSpace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Poll removal of all finalizers from KeyCloakClients from a namespace
+func removeKeyCloakClientFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
+		clients := &keycloakv1alpha1.KeycloakClientList{}
+
+		err = ctx.Client.List(goctx.TODO(), clients, &k8sclient.ListOptions{
+			Namespace: nameSpace,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, client := range clients.Items {
+			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &client, func() error {
+				client.Finalizers = []string{}
+				return nil
+			})
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+// Poll removal of all finalizers from KeyCloakRealms from a namespace
+func removeKeyCloakRealmFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
+		realms := &keycloakv1alpha1.KeycloakRealmList{}
+
+		err = ctx.Client.List(goctx.TODO(), realms, &k8sclient.ListOptions{
+			Namespace: nameSpace,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, realm := range realms.Items {
+			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &realm, func() error {
+				realm.Finalizers = []string{}
+				return nil
+			})
+
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+// Poll removal of all finalizers from KeyCloakUsers from a namespace
+func removeKeyCloakUserFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
+		users := &keycloakv1alpha1.KeycloakUserList{}
+
+		err = ctx.Client.List(goctx.TODO(), users, &k8sclient.ListOptions{
+			Namespace: nameSpace,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, user := range users.Items {
+			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &user, func() error {
+				user.Finalizers = []string{}
+				return nil
+			})
+
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+// Remove finalizers from Monitoring resources in a target namespace
+func removeMonitoringFinalizers(ctx *TestingContext, nameSpace string) error {
+
+	err := removeBlackBoxTargetFinalizers(ctx, nameSpace)
+	if err != nil {
+		return err
+	}
+
+	err = removeApplicationMonitoringFinalizers(ctx, nameSpace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Poll removal of all finalizers from BlackBoxTargets from a namespace
+func removeBlackBoxTargetFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
+		blackBoxes := &monitoringv1alpha1.BlackboxTargetList{}
+
+		err = ctx.Client.List(goctx.TODO(), blackBoxes, &k8sclient.ListOptions{
+			Namespace: nameSpace,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, blackBox := range blackBoxes.Items {
+			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &blackBox, func() error {
+				blackBox.Finalizers = []string{}
+				return nil
+			})
+
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+// Poll removal of all finalizers from ApplicationMonitorings from a namespace
+func removeApplicationMonitoringFinalizers(ctx *TestingContext, nameSpace string) error {
+	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
+		applicationMonitorings := &monitoringv1alpha1.ApplicationMonitoringList{}
+
+		err = ctx.Client.List(goctx.TODO(), applicationMonitorings, &k8sclient.ListOptions{
+			Namespace: nameSpace,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, applicationMonitoring := range applicationMonitorings.Items {
+			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &applicationMonitoring, func() error {
+				applicationMonitoring.Finalizers = []string{}
+				return nil
+			})
+
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+func getStagesForInstallType(installType string) []StageDeletion {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(commonStages, managedApiStages...)
+	} else {
+		return append(commonStages, rhmiSpecificStages...)
+	}
+}

--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -1,0 +1,268 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	projectv1 "github.com/openshift/api/project/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	projectName         = "project-test-e2e"
+	serviceName         = "testing-curl"
+	podName             = "testing-curl"
+	containerName       = "testing-curl"
+	threescaleNamespace = NamespacePrefix + "3scale"
+	podEndpoitResponse  = "success"
+)
+
+func TestNetworkPolicyAccessNSToSVC(t TestingTB, ctx *TestingContext) {
+	dedicatedAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// console master url
+	masterURL := rhmi.Spec.MasterURL
+
+	// get dedicated admin token
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+		t.Fatalf("error occured trying to get token : %v", err)
+	}
+
+	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
+
+	// creating a project as dedicated-admin
+	_, err = createProject(ctx, openshiftClient)
+	if err != nil {
+		t.Fatalf("error occured while creating a project: %v", err)
+	}
+
+	// creating service as dedicated-admin
+	serviceCR, err := createService(ctx, openshiftClient)
+	if err != nil {
+		t.Fatalf("error occured while creating a service: %v", err)
+	}
+
+	// creating pod as dedicated-admin
+	podCR, err := createPodWithAnEndpoint(ctx, openshiftClient)
+	if err != nil {
+		//t.Fatalf("error occured while creating a pod: %v", err)
+		// Fails to create pod on osde2e - skipping for now
+		t.Skipf("error occured while creating a pod: %v", err)
+	}
+
+	podReady, err := checkPodStatus(ctx, podCR)
+	if err != nil {
+		t.Fatalf("error checking pod status: %v", err)
+	}
+
+	if podReady == false {
+		t.Fatalf("pod %s failed to become ready", podCR.GetName())
+	}
+
+	tsApicastPod, err := get3ScaleAPIcastPod(ctx)
+	if err != nil {
+		t.Fatalf("error getting 3scale apicast pod: %v", err)
+	}
+
+	curlCommand := fmt.Sprintf("curl %s.%s.svc.cluster.local", serviceCR.GetName(), serviceCR.GetNamespace())
+	apicastContainerName := "apicast-production"
+	outputCurlCommand, err := execToPod(curlCommand,
+		tsApicastPod.GetName(),
+		tsApicastPod.GetNamespace(),
+		apicastContainerName,
+		ctx)
+	if err != nil {
+		t.Fatalf("error occured while executing curl command in pod: %v", err)
+	}
+
+	if strings.TrimSpace(outputCurlCommand) != podEndpoitResponse {
+		t.Fatalf("Failed to validate response Pod apicast received %s, instead of %s", outputCurlCommand, podEndpoitResponse)
+	}
+
+	defer cleanUp(ctx)
+
+}
+
+// creating project as dedicated admin
+func createProject(ctx *TestingContext, openshiftClient *resources.OpenshiftClient) (*projectv1.ProjectRequest, error) {
+	projectCR := &projectv1.ProjectRequest{
+		ObjectMeta: v1.ObjectMeta{
+			Name: projectName,
+		},
+	}
+
+	// check if project exist
+	err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: projectName}, &projectv1.Project{})
+	if err != nil && !k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("error occured while retrieving a project: %v", err)
+	} else if k8serr.IsNotFound(err) {
+		if err := openshiftClient.DoOpenshiftCreateProject(projectCR); err != nil {
+			return nil, fmt.Errorf("error occured while making request to create a project: %v", err)
+		}
+	}
+
+	return projectCR, nil
+}
+
+// creates service as dedicated-admin
+func createService(ctx *TestingContext, openshiftClient *resources.OpenshiftClient) (*corev1.Service, error) {
+	serviceCR := &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: projectName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				corev1.ServicePort{
+					Protocol:   corev1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Selector: getTestingCurlLabels(),
+		},
+	}
+
+	// check if service exist
+	key := k8sclient.ObjectKey{Name: serviceCR.GetName(), Namespace: serviceCR.GetNamespace()}
+	err := ctx.Client.Get(goctx.TODO(), key, serviceCR)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("error occured while retrieving service %s : %v", serviceCR.GetName(), err)
+	} else if k8serr.IsNotFound(err) {
+		err = openshiftClient.DoOpenshiftCreateServiceInANamespace(projectName, serviceCR)
+		if err != nil {
+			return nil, fmt.Errorf("error occured while making request to create service %s : %v", serviceCR.GetName(), err)
+		}
+	}
+
+	return serviceCR, nil
+}
+
+func createPodWithAnEndpoint(ctx *TestingContext, openshiftClient *resources.OpenshiftClient) (*corev1.Pod, error) {
+
+	podCR := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      podName,
+			Labels:    getTestingCurlLabels(),
+			Namespace: projectName,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				corev1.Container{
+					Name:  containerName,
+					Image: "busybox:1.31.1",
+					Command: []string{
+						"/bin/sh",
+					},
+					Args: []string{
+						"-c",
+						fmt.Sprintf("while true ; do  echo -e \"HTTP/1.1 200 OK\n\n %s \" | nc -l -p 8080  ; done", podEndpoitResponse),
+					},
+					Ports: []corev1.ContainerPort{
+						corev1.ContainerPort{
+							ContainerPort: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// check if pod exist
+	key := k8sclient.ObjectKey{Name: podCR.GetName(), Namespace: podCR.GetNamespace()}
+	err := ctx.Client.Get(goctx.TODO(), key, podCR)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("error occured while retrieving pod %s : %v", podCR.GetName(), err)
+	} else if k8serr.IsNotFound(err) {
+		err = openshiftClient.DoOpenshiftCreatePodInANamespace(projectName, podCR)
+		if err != nil {
+			return nil, fmt.Errorf("error occured while making request to create pod %s : %v", podCR.GetName(), err)
+		}
+	}
+
+	return podCR, nil
+
+}
+
+func checkPodStatus(ctx *TestingContext, podCR *corev1.Pod) (bool, error) {
+	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		key := k8sclient.ObjectKey{Name: podCR.GetName(), Namespace: podCR.GetNamespace()}
+		err = ctx.Client.Get(goctx.TODO(), key, podCR)
+		if err != nil {
+			return false, fmt.Errorf("error getting pod: %v", err)
+		}
+
+		for _, cnd := range podCR.Status.Conditions {
+			if cnd.Type == corev1.ContainersReady && cnd.Status == corev1.ConditionStatus("True") {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func get3ScaleAPIcastPod(ctx *TestingContext) (*corev1.Pod, error) {
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"threescale_component": "apicast",
+		}),
+		k8sclient.InNamespace(threescaleNamespace),
+	}
+
+	tsApicastPods := &corev1.PodList{}
+	err := ctx.Client.List(goctx.TODO(), tsApicastPods, listOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error listing 3scale apicast pods: %v", err)
+	}
+
+	if len(tsApicastPods.Items) == 0 {
+		return nil, fmt.Errorf("Expected 3scale apicast pods to be created, none found")
+	}
+
+	return &tsApicastPods.Items[0], nil
+}
+
+func getTestingCurlLabels() map[string]string {
+	return map[string]string{
+		"app": "testing-curl",
+	}
+}
+
+func cleanUp(ctx *TestingContext) error {
+	project := &projectv1.Project{ObjectMeta: v1.ObjectMeta{Name: projectName}}
+	service := &corev1.Service{ObjectMeta: v1.ObjectMeta{Name: serviceName, Namespace: projectName}}
+	pod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: projectName}}
+
+	models := []runtime.Object{pod, service, project}
+	for _, model := range models {
+		if err := ctx.Client.Delete(goctx.TODO(), model); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/common/operand_versions.go
+++ b/test/common/operand_versions.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+)
+
+var (
+	rhmi2ProductVersions = map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.ProductVersion{
+		integreatlyv1alpha1.AuthenticationStage: {
+			integreatlyv1alpha1.ProductRHSSO: integreatlyv1alpha1.VersionRHSSO,
+		},
+		integreatlyv1alpha1.MonitoringStage: {
+			integreatlyv1alpha1.ProductMonitoring: integreatlyv1alpha1.VersionMonitoring,
+		},
+		integreatlyv1alpha1.CloudResourcesStage: {
+			integreatlyv1alpha1.ProductCloudResources: integreatlyv1alpha1.VersionCloudResources,
+		},
+		integreatlyv1alpha1.ProductsStage: {
+			integreatlyv1alpha1.Product3Scale:              integreatlyv1alpha1.Version3Scale,
+			integreatlyv1alpha1.ProductFuse:                integreatlyv1alpha1.VersionFuseOnOpenshift,
+			integreatlyv1alpha1.ProductRHSSOUser:           integreatlyv1alpha1.VersionRHSSOUser,
+			integreatlyv1alpha1.ProductCodeReadyWorkspaces: integreatlyv1alpha1.VersionCodeReadyWorkspaces,
+			integreatlyv1alpha1.ProductAMQOnline:           integreatlyv1alpha1.VersionAMQOnline,
+			integreatlyv1alpha1.ProductUps:                 integreatlyv1alpha1.VersionUps,
+			integreatlyv1alpha1.ProductApicurito:           integreatlyv1alpha1.VersionApicurito,
+		},
+		integreatlyv1alpha1.SolutionExplorerStage: {
+			integreatlyv1alpha1.ProductSolutionExplorer: integreatlyv1alpha1.VersionSolutionExplorer,
+		},
+	}
+
+	managedApiProductVersions = map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.ProductVersion{
+		integreatlyv1alpha1.AuthenticationStage: {
+			integreatlyv1alpha1.ProductRHSSO: integreatlyv1alpha1.VersionRHSSO,
+		},
+		integreatlyv1alpha1.MonitoringStage: {
+			integreatlyv1alpha1.ProductMonitoring: integreatlyv1alpha1.VersionMonitoring,
+		},
+		integreatlyv1alpha1.CloudResourcesStage: {
+			integreatlyv1alpha1.ProductCloudResources: integreatlyv1alpha1.VersionCloudResources,
+		},
+		integreatlyv1alpha1.ProductsStage: {
+			integreatlyv1alpha1.Product3Scale:    integreatlyv1alpha1.Version3Scale,
+			integreatlyv1alpha1.ProductRHSSOUser: integreatlyv1alpha1.VersionRHSSOUser,
+		},
+	}
+)
+
+func TestProductVersions(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+
+	productVersions := getProductVersions(rhmi.Spec.Type)
+
+	for stage := range productVersions {
+		for productName, productVersion := range productVersions[stage] {
+			productStatus := rhmi.Status.Stages[stage].Products[productName]
+			clusterVersion := productStatus.Version
+			if clusterVersion != productVersion {
+				t.Errorf("Error with version of %s deployed on cluster. Expected %s. Got %s\nProduct status: %v", productName, productVersion, clusterVersion, productStatus)
+			}
+		}
+
+	}
+}
+
+func getProductVersions(installType string) map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.ProductVersion {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiProductVersions
+	} else {
+		return rhmi2ProductVersions
+	}
+}

--- a/test/common/operator_versions.go
+++ b/test/common/operator_versions.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+)
+
+var (
+	rhmiProductOperatorVersions = map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.OperatorVersion{
+		integreatlyv1alpha1.AuthenticationStage: {
+			integreatlyv1alpha1.ProductRHSSO: integreatlyv1alpha1.OperatorVersionRHSSO,
+		},
+		integreatlyv1alpha1.MonitoringStage: {
+			integreatlyv1alpha1.ProductMonitoring: integreatlyv1alpha1.OperatorVersionMonitoring,
+		},
+		integreatlyv1alpha1.CloudResourcesStage: {
+			integreatlyv1alpha1.ProductCloudResources: integreatlyv1alpha1.OperatorVersionCloudResources,
+		},
+		integreatlyv1alpha1.ProductsStage: {
+			integreatlyv1alpha1.Product3Scale:              integreatlyv1alpha1.OperatorVersion3Scale,
+			integreatlyv1alpha1.ProductFuse:                integreatlyv1alpha1.OperatorVersionFuse,
+			integreatlyv1alpha1.ProductRHSSOUser:           integreatlyv1alpha1.OperatorVersionRHSSOUser,
+			integreatlyv1alpha1.ProductCodeReadyWorkspaces: integreatlyv1alpha1.OperatorVersionCodeReadyWorkspaces,
+			integreatlyv1alpha1.ProductAMQOnline:           integreatlyv1alpha1.OperatorVersionAMQOnline,
+			integreatlyv1alpha1.ProductUps:                 integreatlyv1alpha1.OperatorVersionUPS,
+			integreatlyv1alpha1.ProductApicurito:           integreatlyv1alpha1.OperatorVersionApicurito,
+		},
+		integreatlyv1alpha1.SolutionExplorerStage: {
+			integreatlyv1alpha1.ProductSolutionExplorer: integreatlyv1alpha1.OperatorVersionSolutionExplorer,
+		},
+	}
+	managedApiProductOperatorVersions = map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.OperatorVersion{
+		integreatlyv1alpha1.AuthenticationStage: {
+			integreatlyv1alpha1.ProductRHSSO: integreatlyv1alpha1.OperatorVersionRHSSO,
+		},
+		integreatlyv1alpha1.MonitoringStage: {
+			integreatlyv1alpha1.ProductMonitoring: integreatlyv1alpha1.OperatorVersionMonitoring,
+		},
+		integreatlyv1alpha1.CloudResourcesStage: {
+			integreatlyv1alpha1.ProductCloudResources: integreatlyv1alpha1.OperatorVersionCloudResources,
+		},
+		integreatlyv1alpha1.ProductsStage: {
+			integreatlyv1alpha1.Product3Scale:    integreatlyv1alpha1.OperatorVersion3Scale,
+			integreatlyv1alpha1.ProductRHSSOUser: integreatlyv1alpha1.OperatorVersionRHSSOUser,
+		},
+	}
+)
+
+func TestProductOperatorVersions(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+
+	operatorVersions := getOperatorVersions(rhmi.Spec.Type)
+
+	for stage := range operatorVersions {
+		for productName, operatorVersion := range operatorVersions[stage] {
+			clusterVersion := rhmi.Status.Stages[stage].Products[productName].OperatorVersion
+			if clusterVersion != operatorVersion {
+				t.Errorf("Error with version of %s operator deployed on cluster. Expected %s. Got %s", productName, operatorVersion, clusterVersion)
+			}
+		}
+
+	}
+}
+
+func getOperatorVersions(installType string) map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.OperatorVersion {
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiProductOperatorVersions
+	} else {
+		return rhmiProductOperatorVersions
+	}
+}

--- a/test/common/pdbs_exist.go
+++ b/test/common/pdbs_exist.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"context"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getKeycloakNamespaces() []Namespace {
+	return []Namespace{
+		{
+			Name: NamespacePrefix + "rhsso",
+			PodDisruptionBudgetNames: []string{
+				"keycloak",
+			},
+		},
+		{
+			Name: NamespacePrefix + "user-sso",
+			PodDisruptionBudgetNames: []string{
+				"keycloak",
+			},
+		},
+		// {
+		// 	Name: NamespacePrefix + "3scale",
+		// 	PodDisruptionBudgetNames: []string{
+		// 		"apicast-production",
+		// 		"apicast-staging",
+		// 		"backend-cron",
+		// 		"backend-listener",
+		// 		"backend-worker",
+		// 		"system-app",
+		// 		"system-sidekiq",
+		// 		"zync",
+		// 		"zync-que",
+		// 	},
+		// },
+	}
+}
+
+func TestIntegreatlyPodDisruptionBudgetsExist(t TestingTB, ctx *TestingContext) {
+	for _, namespace := range getKeycloakNamespaces() {
+		for _, podDisruptionBudgetName := range namespace.PodDisruptionBudgetNames {
+			_, err := ctx.KubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace.Name).Get(context.TODO(), podDisruptionBudgetName, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("PodDisruptionBudget %s not found in namespace %s - Error: %s", podDisruptionBudgetName, namespace.Name, err)
+			}
+		}
+	}
+}

--- a/test/common/priority_validate.go
+++ b/test/common/priority_validate.go
@@ -1,0 +1,159 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func priorityStatefulSets() []StatefulSets {
+	return []StatefulSets{
+		{
+			Namespace: NamespacePrefix + "rhsso",
+			Name:      "keycloak",
+		},
+		{
+			Namespace: NamespacePrefix + "user-sso",
+			Name:      "keycloak",
+		},
+	}
+}
+
+func priorityDeploymentConfigs() []DeploymentConfigs {
+	return []DeploymentConfigs{
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "apicast-production",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "apicast-staging",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "backend-cron",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "backend-listener",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "backend-worker",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "system-app",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "system-memcache",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "system-sidekiq",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "system-sphinx",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "zync",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "zync-database",
+		},
+		{
+			Namespace: NamespacePrefix + "3scale",
+			Name:      "zync-que",
+		},
+	}
+}
+
+// TestPriorityClass tests to ensure the pod priority class is created and verifies the deploymentconfigs and statefulsets are updated correctly
+func TestPriorityClass(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+
+	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		t.Skip("Skipping test as this is not a managed api install")
+	}
+
+	priorityClass := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rhmi.Spec.PriorityClassName,
+		},
+	}
+
+	err = checkPriorityClassExists(priorityClass, ctx)
+	if err != nil {
+		t.Errorf("Error %v", err)
+	}
+
+	for _, priority := range priorityStatefulSets() {
+		item, err := ctx.KubeClient.AppsV1().StatefulSets(priority.Namespace).Get(context.TODO(), priority.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		err = checkStatefulSetPriorityIsSet(item, rhmi.Spec.PriorityClassName)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+	}
+
+	for _, priority := range priorityDeploymentConfigs() {
+		deploymentConfig := &openshiftappsv1.DeploymentConfig{ObjectMeta: metav1.ObjectMeta{Name: priority.Name, Namespace: priority.Namespace}}
+		err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: deploymentConfig.Name, Namespace: deploymentConfig.Namespace}, deploymentConfig)
+
+		if err != nil {
+			t.Errorf("Error: %v", err)
+			break
+		}
+
+		err = checkDeploymentConfigPriorityIsSet(deploymentConfig, rhmi.Spec.PriorityClassName)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+	}
+}
+
+func checkStatefulSetPriorityIsSet(statefulSet *appsv1.StatefulSet, priorityClassName string) error {
+	if statefulSet.Spec.Template.Spec.PriorityClassName != priorityClassName {
+		return fmt.Errorf("priorityClassName is not set in statefulSet %v", statefulSet.Name)
+	}
+	return nil
+}
+
+func checkDeploymentConfigPriorityIsSet(deploymentConfig *openshiftappsv1.DeploymentConfig, priorityClassName string) error {
+	if deploymentConfig.Spec.Template.Spec.PriorityClassName != priorityClassName {
+		return fmt.Errorf("priorityClassName is not set in statefulSet %v", deploymentConfig.Name)
+	}
+	return nil
+}
+
+func checkPriorityClassExists(priorityClass *schedulingv1.PriorityClass, ctx *TestingContext) error {
+	//err := ctx.Client.Get(goctx.TODO(), priorityClass, &k8sclient.ListOptions{Namespace: ""})
+
+	_, err := ctx.KubeClient.SchedulingV1().PriorityClasses().Get(context.TODO(), priorityClass.Name, metav1.GetOptions{})
+
+	if err != nil {
+		return fmt.Errorf("priority Class : %v", err)
+
+	}
+
+	fmt.Print(priorityClass.Name)
+	return nil
+}

--- a/test/common/pvc_validate.go
+++ b/test/common/pvc_validate.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// applicable to the rhmi 2 installTypes
+func rhmi2PvcNamespaces() []PersistentVolumeClaim {
+	return []PersistentVolumeClaim{
+		{
+
+			Namespace: NamespacePrefix + "fuse",
+			PersistentVolumeClaimNames: []string{
+				"syndesis-meta",
+				"syndesis-prometheus",
+			},
+		},
+		{
+
+			Namespace: NamespacePrefix + "solution-explorer",
+			PersistentVolumeClaimNames: []string{
+				"user-walkthroughs",
+			},
+		},
+		{
+
+			Namespace: NamespacePrefix + "operator",
+			PersistentVolumeClaimNames: []string{
+				"standard-authservice-postgresql",
+			},
+		},
+	}
+}
+
+// common to all installTypes including managed-api
+func commonPvcNamespaces() []PersistentVolumeClaim {
+	return []PersistentVolumeClaim{
+		{
+
+			Namespace: NamespacePrefix + "middleware-monitoring-operator",
+			PersistentVolumeClaimNames: []string{
+				"prometheus-application-monitoring-db-prometheus-application-monitoring-0",
+			},
+		},
+	}
+}
+
+func TestPVClaims(t TestingTB, ctx *TestingContext) {
+
+	//get full list of volume claim items
+	pvcs := &corev1.PersistentVolumeClaimList{}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+	pvcNamespaces := getPvcNamespaces(rhmi.Spec.Type)
+
+	for _, pvcNamespace := range pvcNamespaces {
+		err := ctx.Client.List(goctx.TODO(), pvcs, &k8sclient.ListOptions{Namespace: pvcNamespace.Namespace})
+		if err != nil {
+			t.Errorf("Error getting PVCs for namespace: %v %w", pvcNamespace.Namespace, err)
+			continue
+		}
+		for _, claim := range pvcNamespace.PersistentVolumeClaimNames {
+			//check if claim exists
+			err := checkForClaim(claim, pvcs)
+			if err != nil {
+				t.Errorf("Persistant Volume Claim: %v %v", claim, err)
+			}
+
+		}
+	}
+}
+
+func getPvcNamespaces(installType string) []PersistentVolumeClaim {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonPvcNamespaces()
+	} else {
+		return append(commonPvcNamespaces(), rhmi2PvcNamespaces()...)
+	}
+}
+
+func checkForClaim(claim string, pvcs *corev1.PersistentVolumeClaimList) error {
+
+	//Check claim exists and is bound.
+	for _, pvc := range pvcs.Items {
+		if claim == pvc.Name {
+			if pvc.Status.Phase == "Bound" {
+				return nil
+			}
+			return fmt.Errorf("not bound")
+		}
+	}
+	return fmt.Errorf("not found")
+
+}

--- a/test/common/rhmi_config.go
+++ b/test/common/rhmi_config.go
@@ -1,0 +1,380 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	goctx "context"
+
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	userv1 "github.com/openshift/api/user/v1"
+	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	RHMIConfigCRName = "rhmi-config"
+	pollInterval     = 1 * time.Second
+	pollTimeout      = 30 * time.Second
+)
+
+// we reuse this struct in tests A21 and A22
+type MaintenanceBackup struct {
+	Backup      v1alpha1.Backup
+	Maintenance v1alpha1.Maintenance
+}
+
+// this state check covers test case - A22
+// verify that the RHMIConfig validation webhook for Maintenance and Backup values work as expected
+var maintenanceBackupStates = map[MaintenanceBackup]func(TestingTB) func(error) error{
+	// we expect no error as blank strings will be set to default vals
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "",
+		},
+	}: assertNoError,
+	// valid input format hh:mm and ddd hh:mm
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "20:05",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Sun 22:10",
+		},
+	}: assertNoError,
+	// we expect an error due to both times being parsed as a 1 hour window
+	// for aws these windows can not overlap
+	// this state provides overlapping times
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "20:05",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Sun 20:15",
+		},
+	}: assertValidationError,
+	// another overlap check, we want to ensure we get an error from a single minute overlap
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "20:15",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Thu 19:16",
+		},
+	}: assertValidationError,
+	// we expect the following :
+	//  * Backup hh:mm
+	//  * Maintenance ddd hh:mm
+	// the following checks will verify malformed times
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "26:00",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Sun 12:05",
+		},
+	}: assertValidationError,
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "22:00",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Malformed 12:05",
+		},
+	}: assertValidationError,
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "malformed",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Sun 20:00",
+		},
+	}: assertValidationError,
+	{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "20:00",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "malformed",
+		},
+	}: assertValidationError,
+}
+
+var upgradeSectionStates = map[v1alpha1.Upgrade]func(TestingTB) func(error) error{
+	{}: assertNoError,
+
+	{
+		NotBeforeDays: intPtr(-1),
+		Schedule:      boolPtr(true),
+	}: assertValidationError,
+
+	{
+		NotBeforeDays:      intPtr(7),
+		WaitForMaintenance: boolPtr(true),
+		Schedule:           boolPtr(true),
+	}: assertNoError,
+}
+
+// TestRHMIConfigCRs tests that the RHMIConfig CR is created successfuly and
+// validated.
+func TestRHMIConfigCRs(t TestingTB, ctx *TestingContext) {
+	t.Log("Test rhmi config cr creation")
+
+	rhmiConfig := RHMIConfigTemplate()
+
+	// we need to delete the CR to ensure it is a blank CR for validation/creation
+	deleteRHMIConfigCR(t, ctx.Client, rhmiConfig)
+
+	// Wait for the ValidatingWebhookConfiguration to be reconciled. In the edge
+	// case that this test is run so fast that the operator mightn't have had
+	// time to reconcile it.
+	if err := waitForValidatingWebhook(ctx.Client); err != nil {
+		t.Fatalf("Error waiting for ValidatingWebhookConfiguration: %v", err)
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, rhmiConfig, func() error {
+		return nil
+	}); err != nil {
+		t.Fatalf("Failed to create RHMI Config resource %v", err)
+	}
+
+	// Test the CR is created with default values
+	verifyCr(t, ctx)
+
+	// Verify the Mutating webhook
+	// Use polling to avoid unnecessary test failure due to an error
+	// when trying to update modified object
+	// More info in https://github.com/integr8ly/integreatly-operator/pull/1279
+	err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+		newErr := verifyRHMIConfigMutatingWebhook(ctx, t)
+		if newErr != nil {
+			return false, newErr
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("Timed out when trying to verify RHMI Config Mutating Webhook: %s", err)
+	}
+
+	// Test each possible state for the Upgrade section
+	for state, assertion := range upgradeSectionStates {
+		t.Logf("Testing the RHMIConfig state: %s", logUpgrade(state))
+		err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+			newErr := verifyRHMIConfigValidation(ctx.Client, assertion(t), func(cr *v1alpha1.RHMIConfig) {
+				cr.Spec.Upgrade = state
+			})
+			if newErr != nil {
+				return false, newErr
+			}
+			return true, nil
+
+		})
+		if err != nil {
+			t.Errorf("Timed out when trying to test states for the Upgrade section: %s", err)
+		}
+
+	}
+
+	// test for possible state changes for the Backup and Maintenance section
+	for state, assertion := range maintenanceBackupStates {
+
+		err := wait.Poll(pollInterval, pollTimeout, func() (done bool, err error) {
+			newErr := verifyRHMIConfigValidation(ctx.Client, assertion(t), func(cr *v1alpha1.RHMIConfig) {
+				cr.Spec.Maintenance.ApplyFrom = state.Maintenance.ApplyFrom
+				cr.Spec.Backup.ApplyOn = state.Backup.ApplyOn
+			})
+			if newErr != nil {
+				return false, newErr
+			}
+			return true, nil
+		})
+		if err != nil {
+			t.Errorf("Timed out when trying to test states for the maintenance and backup sections: %s", err)
+		}
+	}
+}
+
+func verifyCr(t TestingTB, ctx *TestingContext) {
+	t.Log("Verify rhmi config cr creation")
+
+	rhmiConfig := &v1alpha1.RHMIConfig{}
+
+	err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: RHMIConfigCRName, Namespace: RHMIOperatorNamespace}, rhmiConfig)
+	if err != nil {
+		t.Fatalf("Failed to verify RHMI Config resource %v", err)
+	}
+
+	// The upgrade fields should default to false
+	if *rhmiConfig.Spec.Upgrade.WaitForMaintenance != true {
+		t.Errorf("WaitForMaintenance should be true by default. Got %v",
+			rhmiConfig.Spec.Upgrade.WaitForMaintenance)
+	}
+	if *rhmiConfig.Spec.Upgrade.NotBeforeDays != 7 {
+		t.Errorf("NotBeforeDays should be set to 7. Got %v",
+			rhmiConfig.Spec.Upgrade.NotBeforeDays)
+	}
+}
+
+func deleteRHMIConfigCR(t TestingTB, client dynclient.Client, cr *v1alpha1.RHMIConfig) {
+	if err := client.Delete(goctx.TODO(), cr); err != nil {
+		t.Errorf("Failed to delete the rhmi config")
+	}
+}
+
+func verifyRHMIConfigValidation(client dynclient.Client, validateError func(error) error, mutateRHMIConfig func(*v1alpha1.RHMIConfig)) error {
+	rhmiConfig := &v1alpha1.RHMIConfig{}
+
+	if err := client.Get(
+		goctx.TODO(),
+		types.NamespacedName{Name: RHMIConfigCRName, Namespace: RHMIOperatorNamespace},
+		rhmiConfig,
+	); err != nil {
+		return err
+	}
+
+	// Perform the update and validate the error object
+	mutateRHMIConfig(rhmiConfig)
+	return validateError(client.Update(goctx.TODO(), rhmiConfig))
+
+}
+
+// verifyRHMIConfigMutatingWebhook tests the mutating webhook by logging in as
+// a customer admin in the testing IDP and performing an update to the RHMIConfig
+// instance, and checking that the webhooks adds the correct annotations
+func verifyRHMIConfigMutatingWebhook(ctx *TestingContext, t TestingTB) error {
+	currentUser := &userv1.User{}
+	if err := ctx.Client.Get(goctx.TODO(), dynclient.ObjectKey{
+		Name: "~",
+	}, currentUser); err != nil {
+		t.Logf("Error getting the current user: %v", err)
+		return err
+	}
+
+	// Get the current RHMIConfig instance
+	rhmiConfig := &v1alpha1.RHMIConfig{}
+	if err := ctx.Client.Get(
+		goctx.TODO(),
+		types.NamespacedName{Name: RHMIConfigCRName, Namespace: RHMIOperatorNamespace},
+		rhmiConfig,
+	); err != nil {
+		t.Logf("Error getting RHMIConfig instance: %v", err)
+		return err
+	}
+
+	// Update a value in the instance
+	*rhmiConfig.Spec.Upgrade.WaitForMaintenance = false
+
+	// Update the RHMIConfig instance as the customer-admin user
+	if err := ctx.Client.Update(goctx.TODO(), rhmiConfig); err != nil {
+		t.Logf("Error updating RHMIConfig instance: %v", err)
+		return err
+	}
+
+	// Get the updated RHMIConfig instance
+	if err := ctx.Client.Get(
+		goctx.TODO(),
+		types.NamespacedName{Name: RHMIConfigCRName, Namespace: RHMIOperatorNamespace},
+		rhmiConfig,
+	); err != nil {
+		t.Logf("Error getting RHMIConfig instance: %v", err)
+		return err
+	}
+
+	// Verify the username is set in the annotations
+	if rhmiConfig.Annotations["lastEditUsername"] != currentUser.Name {
+		t.Errorf("Expected mutating webhook to add \"%s\" lastEditUsername annotation to RHMIConfig. Got %s instead",
+			currentUser.Name,
+			rhmiConfig.Annotations["lastEditUsername"])
+	}
+
+	// Verify the timestamp is set in the annotations
+	if lastEdit, ok := rhmiConfig.Annotations["lastEditTimestamp"]; ok {
+		if _, err := time.Parse("2 Jan 2006 15:04", lastEdit); err != nil {
+			t.Errorf("Expected lastEditTimestamp to be parsed, but got error: %v", err)
+		}
+	} else {
+		t.Error("Expected mutating webhook to add lastEditTimestamp annotation to RHMIConfig")
+	}
+	return nil
+}
+
+// we require this template across different tests for RHMI config
+// rhmi config we need to use the config map provisioned in the RHMI install
+// this to avoid a conflict of having multiple rhmi configs
+func RHMIConfigTemplate() *v1alpha1.RHMIConfig {
+	return &v1alpha1.RHMIConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      RHMIConfigCRName,
+			Namespace: RHMIOperatorNamespace,
+		},
+	}
+}
+
+func waitForValidatingWebhook(client dynclient.Client) error {
+	return wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
+		vwc := &v1beta1.ValidatingWebhookConfiguration{}
+		err := client.Get(goctx.TODO(),
+			dynclient.ObjectKey{Name: "rhmiconfig.integreatly.org"},
+			vwc,
+		)
+		if err == nil {
+			return true, nil
+		}
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	})
+}
+
+func assertNoError(t TestingTB) func(error) error {
+	return func(err error) error {
+		if err != nil {
+			t.Logf("Expected error to be nil. Got %v", err)
+			return err
+		}
+		return nil
+	}
+}
+
+func assertValidationError(t TestingTB) func(error) error {
+	return func(err error) error {
+		switch e := err.(type) {
+		case errors.APIStatus:
+			if e.Status().Code != 403 {
+				t.Logf("Expected error to be \"Forbidden\", but got: %s", e.Status().Reason)
+				return err
+			}
+		default:
+			t.Logf("Expected error type to be APIStatus type. Got %v", e)
+			return err
+		}
+		return nil
+	}
+}
+
+func logUpgrade(upgrade v1alpha1.Upgrade) string {
+	return fmt.Sprintf(
+		"{ notBeforeDays: %v, waitForMaintenance: %v }",
+		upgrade.NotBeforeDays,
+		upgrade.WaitForMaintenance,
+	)
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/test/common/rhmi_config_cro_strategy_override.go
+++ b/test/common/rhmi_config_cro_strategy_override.go
@@ -1,0 +1,126 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	v12 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	CROStrategyConfigMap = "cloud-resources-aws-strategies"
+)
+
+/*
+  This test is to verify that changes made to the RHMI config are reflected in the
+  Cloud Resource Operator (CRO) strategy override config map
+  CRO uses this strategy to override the parameters to resources CRO provisions
+  RHMI config allows for Maintenance and Backup times
+  We need to ensure these windows are built and updated in the config map
+
+  NOTE :
+	* This test case is : A21
+	* This is to be run as part of the common test cases
+	* Some of the functions are shared with functional/aws_strategy_override.go
+	* aws_strategy_override.go tests full e2e from updating RHMIConfig to updating AWS resource
+*/
+func TestRHMIConfigCROStrategyOverride(t TestingTB, testingCtx *TestingContext) {
+	ctx := context.TODO()
+
+	// rhmi config we need to use is the rhmi config provisioned in the RHMI install
+	// this to avoid a conflict of having multiple rhmi configs
+	rhmiConfig := RHMIConfigTemplate()
+
+	// known valid Backup and Maintenance times
+	expectedMaintenanceAndBackup := MaintenanceBackup{
+		Backup: v1alpha1.Backup{
+			ApplyOn: "12:05",
+		},
+		Maintenance: v1alpha1.Maintenance{
+			ApplyFrom: "Thu 14:15",
+		},
+	}
+	// expected windows built from `expectedMaintenanceAndBackup
+	expectedBackupWindow := "12:05-13:05"
+	expectedMaintenanceWindow := "thu:14:15-thu:15:15"
+
+	// update rhmi config Backup and Maintenance times to valid expected times
+	if err := UpdateRHMIConfigBackupAndMaintenance(ctx, testingCtx.Client, rhmiConfig, expectedMaintenanceAndBackup); err != nil {
+		t.Fatalf("test failed - unable to update rhmi config : %v", err)
+	}
+
+	// ensure strategy config map is as expected
+	// we have added this poll to allow the operator reconcile on the cr and update the strategy override
+	// we expect the change to be immediate, the poll is help with any potential test flake
+	var lastPollError error
+	if err := wait.PollImmediate(time.Second*5, time.Second*30, func() (done bool, err error) {
+		lastPollError = VerifyCROStrategyMap(ctx, testingCtx.Client, expectedBackupWindow, expectedMaintenanceWindow)
+		// If lastPollError is now nil, we've succeeded, return true for 'done' to exit the poll
+		return lastPollError == nil, nil
+	}); err != nil {
+		t.Fatalf("test failed : strategy map not as expected : %v : %v ", lastPollError, err)
+	}
+}
+
+// gets cro strategy map, checks both redis and postgres values to be as expected.
+func VerifyCROStrategyMap(context context.Context, client client.Client, expectedBackupWindow, expectedMaintenanceWindow string) error {
+	var foundErrors []string
+
+	croStrategyConfig := &v12.ConfigMap{}
+	if err := client.Get(context, types.NamespacedName{Name: CROStrategyConfigMap, Namespace: RHMIOperatorNamespace}, croStrategyConfig); err != nil {
+		return fmt.Errorf("unable to get cloud-resources-aws-strategies config map : %v", err)
+	}
+
+	redisExpectedBackupWindow := fmt.Sprintf("\"SnapshotWindow\":\"%s\"", expectedBackupWindow)
+	if !strings.Contains(croStrategyConfig.Data["redis"], redisExpectedBackupWindow) {
+		foundErrors = append(foundErrors, fmt.Sprintf("\n - expected '%s' not found in Redis strategy config map", redisExpectedBackupWindow))
+	}
+	redisExpectedMaintenaceWindow := fmt.Sprintf("\"PreferredMaintenanceWindow\":\"%s\"", expectedMaintenanceWindow)
+	if !strings.Contains(croStrategyConfig.Data["redis"], redisExpectedMaintenaceWindow) {
+		foundErrors = append(foundErrors, fmt.Sprintf("\n - expected '%s' not found in Redis strategy config map", redisExpectedMaintenaceWindow))
+	}
+
+	postgresExpectedBackupWindow := fmt.Sprintf("\"PreferredBackupWindow\":\"%s\"", expectedBackupWindow)
+	if !strings.Contains(croStrategyConfig.Data["postgres"], postgresExpectedBackupWindow) {
+		foundErrors = append(foundErrors, fmt.Sprintf("\n - expected '%s' not found in Postgres strategy config map", postgresExpectedBackupWindow))
+	}
+	postgresExpectedMaintenanceWindow := fmt.Sprintf("\"PreferredMaintenanceWindow\":\"%s\"", expectedMaintenanceWindow)
+	if !strings.Contains(croStrategyConfig.Data["postgres"], postgresExpectedMaintenanceWindow) {
+		foundErrors = append(foundErrors, fmt.Sprintf("\n - expected '%s' not found in Postgres strategy config map", postgresExpectedMaintenanceWindow))
+	}
+
+	if len(foundErrors) != 0 {
+		return fmt.Errorf("\n - Redis data found : \n\t%s\n - Postgres data found : \n\t%s\n %s", croStrategyConfig.Data["redis"], croStrategyConfig.Data["postgres"], foundErrors)
+	}
+
+	return nil
+}
+
+// updates the rhmiconfig backup and maintenance values
+func UpdateRHMIConfigBackupAndMaintenance(context context.Context, client client.Client, rhmiConfig *v1alpha1.RHMIConfig, maintenanceBackup MaintenanceBackup) error {
+	if _, err := controllerutil.CreateOrUpdate(context, client, rhmiConfig, func() error {
+		rhmiConfig.Spec.Maintenance.ApplyFrom = maintenanceBackup.Maintenance.ApplyFrom
+		rhmiConfig.Spec.Backup.ApplyOn = maintenanceBackup.Backup.ApplyOn
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// expected redis value to be returned in cro strat map
+func BuildExpectRedisStrat(backupWindow, maintenanceWindow string) string {
+	return fmt.Sprintf("{\"development\":{\"region\":\"\",\"createStrategy\":{},\"deleteStrategy\":{}},\"production\":{\"region\":\"\",\"createStrategy\":{\"AtRestEncryptionEnabled\":null,\"AuthToken\":null,\"AutoMinorVersionUpgrade\":null,\"AutomaticFailoverEnabled\":null,\"CacheNodeType\":null,\"CacheParameterGroupName\":null,\"CacheSecurityGroupNames\":null,\"CacheSubnetGroupName\":null,\"Engine\":null,\"EngineVersion\":null,\"KmsKeyId\":null,\"NodeGroupConfiguration\":null,\"NotificationTopicArn\":null,\"NumCacheClusters\":null,\"NumNodeGroups\":null,\"Port\":null,\"PreferredCacheClusterAZs\":null,\"PreferredMaintenanceWindow\":\"%s\",\"PrimaryClusterId\":null,\"ReplicasPerNodeGroup\":null,\"ReplicationGroupDescription\":null,\"ReplicationGroupId\":null,\"SecurityGroupIds\":null,\"SnapshotArns\":null,\"SnapshotName\":null,\"SnapshotRetentionLimit\":null,\"SnapshotWindow\":\"%s\",\"Tags\":null,\"TransitEncryptionEnabled\":null},\"deleteStrategy\":{}}}", maintenanceWindow, backupWindow)
+}
+
+// expected postgres value to be returned in cro strat map
+func buildExpectPostgresStrat(backupWindow, maintenanceWindow string) string {
+	return fmt.Sprintf("{\"development\":{\"region\":\"\",\"createStrategy\":{},\"deleteStrategy\":{}},\"production\":{\"region\":\"\",\"createStrategy\":{\"AllocatedStorage\":null,\"AutoMinorVersionUpgrade\":null,\"AvailabilityZone\":null,\"BackupRetentionPeriod\":null,\"CharacterSetName\":null,\"CopyTagsToSnapshot\":null,\"DBClusterIdentifier\":null,\"DBInstanceClass\":null,\"DBInstanceIdentifier\":null,\"DBName\":null,\"DBParameterGroupName\":null,\"DBSecurityGroups\":null,\"DBSubnetGroupName\":null,\"DeletionProtection\":null,\"Domain\":null,\"DomainIAMRoleName\":null,\"EnableCloudwatchLogsExports\":null,\"EnableIAMDatabaseAuthentication\":null,\"EnablePerformanceInsights\":null,\"Engine\":null,\"EngineVersion\":null,\"Iops\":null,\"KmsKeyId\":null,\"LicenseModel\":null,\"MasterUserPassword\":null,\"MasterUsername\":null,\"MaxAllocatedStorage\":null,\"MonitoringInterval\":null,\"MonitoringRoleArn\":null,\"MultiAZ\":null,\"OptionGroupName\":null,\"PerformanceInsightsKMSKeyId\":null,\"PerformanceInsightsRetentionPeriod\":null,\"Port\":null,\"PreferredBackupWindow\":\"%s\",\"PreferredMaintenanceWindow\":\"%s\",\"ProcessorFeatures\":null,\"PromotionTier\":null,\"PubliclyAccessible\":null,\"StorageEncrypted\":null,\"StorageType\":null,\"Tags\":null,\"TdeCredentialArn\":null,\"TdeCredentialPassword\":null,\"Timezone\":null,\"VpcSecurityGroupIds\":null},\"deleteStrategy\":{}}}", backupWindow, maintenanceWindow)
+}

--- a/test/common/rhmicr_metrics.go
+++ b/test/common/rhmicr_metrics.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestRHMICRMetrics(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	rhmiOperatorPod, err := getRHMIOperatorPod(ctx)
+	if err != nil {
+		t.Fatalf("error getting rhmi-operator pod: %v", err)
+	}
+
+	output, err := execToPod("curl --silent localhost:8383/metrics",
+		rhmiOperatorPod.Name,
+		RHMIOperatorNamespace,
+		"rhmi-operator",
+		ctx)
+	if err != nil {
+		t.Fatalf("failed to exec to prometheus pod: %v", err)
+	}
+
+	// check if rhmi_status is present
+	rhmiStatusMetricPresent := regexp.MustCompile(`rhmi_status{.*}`)
+	if !rhmiStatusMetricPresent.MatchString(output) {
+		t.Fatalf("rhmi_status metric is not present. Metrics output:\n%v", output)
+	}
+
+	// check if the metric labels matches rhmi CR
+	stringRHMIStatus := rhmiStatusMetricPresent.FindString(output)
+	labels := parsePrometheusMetricToMap(stringRHMIStatus, "rhmi_status")
+	if labels["stage"] != string(rhmi.Status.Stage) {
+		t.Fatalf("rhmi_status metric stage does not match current stage: %s != %s", labels["stage"], string(rhmi.Status.Stage))
+	}
+
+	// check if rhmi_info is present
+	rhmiInfoMetricPresent := regexp.MustCompile(`rhmi_spec{.*}`)
+	if !rhmiInfoMetricPresent.MatchString(output) {
+		t.Fatalf("rhmi_spec metric is not present. Metrics output:\n%v", output)
+	}
+
+	// check if rhmi_info metric labels matches with rhmi installation CR
+	stringRHMIInfo := rhmiInfoMetricPresent.FindString(output)
+	rhmiInfoLabels := parsePrometheusMetricToMap(stringRHMIInfo, "rhmi_spec")
+
+	doRHMIInfoLabelsMatch := true
+	if rhmiInfoLabels["use_cluster_storage"] != rhmi.Spec.UseClusterStorage ||
+		rhmiInfoLabels["master_url"] != rhmi.Spec.MasterURL ||
+		rhmiInfoLabels["installation_type"] != rhmi.Spec.Type ||
+		rhmiInfoLabels["operator_name"] != rhmi.GetName() ||
+		rhmiInfoLabels["namespace"] != rhmi.GetNamespace() ||
+		rhmiInfoLabels["namespace_prefix"] != rhmi.Spec.NamespacePrefix ||
+		rhmiInfoLabels["operators_in_product_namespace"] != fmt.Sprintf("%t", rhmi.Spec.OperatorsInProductNamespace) ||
+		rhmiInfoLabels["routing_subdomain"] != rhmi.Spec.RoutingSubdomain ||
+		rhmiInfoLabels["self_signed_certs"] != fmt.Sprintf("%t", rhmi.Spec.SelfSignedCerts) {
+		doRHMIInfoLabelsMatch = false
+	}
+	if !doRHMIInfoLabelsMatch {
+		t.Fatalf("rhmi_info metric labels do not match with rhmi CR. Labels:\n%v", rhmiInfoLabels)
+	}
+}
+
+func getRHMIOperatorPod(ctx *TestingContext) (*corev1.Pod, error) {
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"name": "rhmi-operator",
+		}),
+		k8sclient.InNamespace(RHMIOperatorNamespace),
+	}
+
+	rhmiOperatorPod := &corev1.PodList{}
+
+	err := ctx.Client.List(goctx.TODO(), rhmiOperatorPod, listOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error listing rhmi-operator pod: %v", err)
+	}
+
+	if len(rhmiOperatorPod.Items) == 0 {
+		return nil, fmt.Errorf("%v pod doesn't exist in namespace: %v (err: %v)", podName, RHMIOperatorNamespace, err)
+	}
+
+	return &rhmiOperatorPod.Items[0], nil
+}
+
+func parsePrometheusMetricToMap(metric, metricName string) map[string]string {
+	// remove unwanted part of the string
+	metric = strings.ReplaceAll(metric, fmt.Sprintf("%s{", metricName), "")
+	metric = strings.ReplaceAll(metric, "}", "")
+
+	labelsWithValue := strings.Split(metric, ",")
+	parsedStrings := map[string]string{}
+	for _, labelAndValue := range labelsWithValue {
+		value := strings.Split(labelAndValue, "=")
+		parsedStrings[value[0]] = strings.ReplaceAll(value[1], "\"", "")
+	}
+	return parsedStrings
+}
+
+func sanitizeForPrometheusLabel(productName integreatlyv1alpha1.ProductName) string {
+	if productName == integreatlyv1alpha1.Product3Scale {
+		productName = "threescale"
+	}
+	return fmt.Sprintf("%s_status", strings.ReplaceAll(string(productName), "-", "_"))
+}

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -1,0 +1,280 @@
+package common
+
+import (
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	goctx "context"
+
+	routev1 "github.com/openshift/api/route/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	threeScaleRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "backend",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-api-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "apicast-staging",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-api-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "apicast-production",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-master-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-master",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-provider-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-developer",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-provider-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-provider",
+		},
+	}
+
+	amqOnlineRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "console",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "standard-authservice",
+			isTLS: true,
+		},
+	}
+
+	codeReadyRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "codeready",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "devfile-registry",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "plugin-registry",
+			isTLS: true,
+		},
+	}
+
+	fuseRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "syndesis",
+			isTLS: true,
+		},
+	}
+
+	middlewareMonitoringRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "alertmanager-route",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "grafana-route",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "prometheus-route",
+			isTLS: true,
+		},
+	}
+
+	rhssoRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "keycloak-edge",
+			isTLS: true,
+		},
+	}
+
+	solutionExplorerRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "solution-explorer",
+			isTLS: true,
+		},
+	}
+
+	upsRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "ups-unifiedpush-proxy",
+			isTLS: true,
+		},
+	}
+
+	userSsoRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "keycloak-edge",
+			isTLS: true,
+		},
+	}
+
+	rhoamUserSsoRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: true,
+		},
+	}
+
+	apicuritoRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "apicurito",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "fuse-apicurito-generator",
+			isTLS: true,
+		},
+	}
+	customerGrafanaRoutes = []ExpectedRoute{
+		{
+			Name:  "grafana-route",
+			isTLS: true,
+		},
+	}
+)
+
+var rhmi2ExpectedRoutes = map[string][]ExpectedRoute{
+	"3scale":                         threeScaleRoutes,
+	"amq-online":                     amqOnlineRoutes,
+	"codeready-workspaces":           codeReadyRoutes,
+	"fuse":                           fuseRoutes,
+	"middleware-monitoring-operator": middlewareMonitoringRoutes,
+	"rhsso":                          rhssoRoutes,
+	"solution-explorer":              solutionExplorerRoutes,
+	"ups":                            upsRoutes,
+	"user-sso":                       userSsoRoutes,
+	"apicurito":                      apicuritoRoutes,
+}
+
+var managedApiExpectedRoutes = map[string][]ExpectedRoute{
+	"3scale":                         threeScaleRoutes,
+	"middleware-monitoring-operator": middlewareMonitoringRoutes,
+	"rhsso":                          rhssoRoutes,
+	"user-sso":                       rhoamUserSsoRoutes,
+	"customer-monitoring-operator":   customerGrafanaRoutes,
+}
+
+// TestIntegreatlyRoutesExist tests that the routes for all the products are created
+func TestIntegreatlyRoutesExist(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+
+	expectedRoutes := getExpectedRoutes(rhmi.Spec.Type)
+
+	for product, routes := range expectedRoutes {
+		for _, expectedRoute := range routes {
+			foundRoute, err := getRoute(t, ctx, product, expectedRoute)
+			if err != nil {
+				t.Errorf("Failed checking route %v for product %v: %v",
+					expectedRoute.Name, product, err)
+
+				continue
+			}
+
+			foundTLS := isTLS(foundRoute)
+			if foundTLS != expectedRoute.isTLS {
+				t.Errorf("Failed checking route %s for product %s: Expected TLS to be %v but got %v",
+					expectedRoute.Name, product, expectedRoute.isTLS, foundTLS)
+			}
+		}
+	}
+}
+
+func getExpectedRoutes(installType string) map[string][]ExpectedRoute {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedApiExpectedRoutes
+	} else {
+		return rhmi2ExpectedRoutes
+	}
+}
+
+func getRoute(t TestingTB, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	if expectedRoute.IsGeneratedName {
+		return getRouteByGeneratedName(t, ctx, product, expectedRoute)
+	}
+
+	return getRouteByName(t, ctx, product, expectedRoute)
+}
+
+// getRouteByName finds a Route by searching for a route that has a matching name
+// to expectedRoute.Name
+func getRouteByName(t TestingTB, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	route := &routev1.Route{}
+	err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: expectedRoute.Name, Namespace: NamespacePrefix + product}, route)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return route, nil
+}
+
+// getRouteByGeneratedName finds a Route by querying the product routes and finding the
+// first route with a generated name that matches expectedRoute.Name and pointing
+// to a service that matches expectedRoute.ServiceName
+func getRouteByGeneratedName(t TestingTB, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	routes := &routev1.RouteList{}
+
+	// Get the routes for the product
+	err := ctx.Client.List(goctx.TODO(), routes, &k8sclient.ListOptions{
+		Namespace: NamespacePrefix + product,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("Error obtaining routes for product %s", product)
+	}
+
+	// Iterate through the routes and look for the one that matches the expected one.
+	// If it's found, check if TLS matches the expected
+	for _, route := range routes.Items {
+		// Skip routes that don't point to services
+		if route.Spec.To.Kind != "Service" {
+			continue
+		}
+
+		generatedName := route.GetObjectMeta().GetGenerateName()
+		to := route.Spec.To.Name
+
+		if expectedRoute.Name == generatedName && expectedRoute.ServiceName == to {
+			return &route, nil
+		}
+	}
+
+	// The loop finished and the expected route wasn't found, return an error
+	return nil, fmt.Errorf("Expected route with generated name %v to service %v was not found for product %v",
+		expectedRoute.Name, expectedRoute.ServiceName, product)
+}
+
+func isTLS(route *routev1.Route) bool {
+	return route.Spec.TLS.Termination == routev1.TLSTerminationEdge ||
+		route.Spec.TLS.Termination == routev1.TLSTerminationReencrypt
+}

--- a/test/common/scale_up_replicas_amqstreams.go
+++ b/test/common/scale_up_replicas_amqstreams.go
@@ -1,0 +1,137 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"strconv"
+	"time"
+
+	kafkav1alpha1 "github.com/integr8ly/integreatly-operator/apis-products/kafka.strimzi.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	numberOfAmqstreamsReplicas  = 2 //size in reconciler
+	scaleUpAmqstreamsReplicas   = 1
+	scaleDownAmqstreamsReplicas = 1
+	amqstreamsName              = "rhmi-cluster"
+	amqstreamsNamespace         = NamespacePrefix + "amq-streams"
+	retryIntervalAmqstreams     = time.Second * 20
+	timeoutAmqstreams           = time.Minute * 7
+)
+
+func TestReplicasInAmqstreams(t TestingTB, ctx *TestingContext) {
+
+	amqstreams, err := getAmqstreams(ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to get amqstreams : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas are set")
+	if err := checkNumberOfReplicasAgainstValueAmqstreams(amqstreams, ctx, numberOfAmqstreamsReplicas, retryIntervalAmqstreams, timeoutAmqstreams, t); err != nil {
+		t.Fatalf("Incorrect number of replicas to start : %v", err)
+	}
+
+	amqstreams, err = updateAmqstreams(ctx.Client, scaleUpAmqstreamsReplicas, t)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueAmqstreams(amqstreams, ctx, scaleUpAmqstreamsReplicas, retryIntervalAmqstreams, timeoutAmqstreams, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	amqstreams, err = updateAmqstreams(ctx.Client, scaleDownAmqstreamsReplicas, t)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueAmqstreams(amqstreams, ctx, numberOfAmqstreamsReplicas, retryIntervalAmqstreams, timeoutAmqstreams, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+}
+
+func getAmqstreams(dynClient k8sclient.Client) (kafkav1alpha1.Kafka, error) {
+	amqstreams := &kafkav1alpha1.Kafka{}
+
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: amqstreamsName, Namespace: amqstreamsNamespace}, amqstreams); err != nil {
+		return *amqstreams, err
+	}
+
+	return *amqstreams, nil
+}
+
+func updateAmqstreams(dynClient k8sclient.Client, replicas int, t TestingTB) (kafkav1alpha1.Kafka, error) {
+
+	amqstreams, err := getAmqstreams(dynClient)
+
+	if err != nil {
+		return amqstreams, err
+	}
+	amqstreams = kafkav1alpha1.Kafka{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            amqstreamsName,
+			Namespace:       amqstreamsNamespace,
+			ResourceVersion: amqstreams.GetResourceVersion(),
+		},
+	}
+
+	amqstreams.APIVersion = fmt.Sprintf("%s/%s", kafkav1alpha1.SchemeGroupVersion.Group, kafkav1alpha1.SchemeGroupVersion.Version)
+	amqstreams.Kind = kafkav1alpha1.KafkaKind
+
+	amqstreams.Name = amqstreamsName
+	amqstreams.Namespace = amqstreamsNamespace
+
+	amqstreams.Spec.Kafka.Version = "2.1.1"
+
+	amqstreams.Spec.Kafka.Replicas = replicas
+	amqstreams.Spec.Zookeeper.Replicas = replicas
+
+	amqstreams.Spec.Kafka.Listeners = map[string]kafkav1alpha1.KafkaListener{
+		"plain": {},
+		"tls":   {},
+	}
+	amqstreams.Spec.Kafka.Config.OffsetsTopicReplicationFactor = strconv.FormatInt(int64(numberOfAmqstreamsReplicas), 1)
+	amqstreams.Spec.Kafka.Config.TransactionStateLogReplicationFactor = strconv.FormatInt(int64(numberOfAmqstreamsReplicas), 1)
+	amqstreams.Spec.Kafka.Config.TransactionStateLogMinIsr = "2"
+	amqstreams.Spec.Kafka.Config.LogMessageFormatVersion = "2.1"
+	amqstreams.Spec.Kafka.Storage.Type = "persistent-claim"
+	amqstreams.Spec.Kafka.Storage.Size = "8Gi"
+	amqstreams.Spec.Kafka.Storage.DeleteClaim = false
+
+	amqstreams.Spec.Zookeeper.Storage.Type = "persistent-claim"
+	amqstreams.Spec.Zookeeper.Storage.Size = "8Gi"
+	amqstreams.Spec.Zookeeper.Storage.DeleteClaim = false
+
+	amqstreams.Spec.EntityOperator.TopicOperator = kafkav1alpha1.KafkaTopicOperator{}
+	amqstreams.Spec.EntityOperator.UserOperator = kafkav1alpha1.KafkaUserOperator{}
+
+	if err := dynClient.Update(goctx.TODO(), amqstreams.DeepCopy(), &k8sclient.UpdateOptions{}); err != nil {
+		return amqstreams, err
+	}
+
+	return amqstreams, nil
+}
+
+func checkNumberOfReplicasAgainstValueAmqstreams(amqstreams kafkav1alpha1.Kafka, ctx *TestingContext, numberOfRequiredReplicas int, retryInterval, timeout time.Duration, t TestingTB) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		amqstreams, err = getAmqstreams(ctx.Client)
+		if err != nil {
+			t.Fatalf("failed to get Apicurito : %v", err)
+		}
+		if *&amqstreams.Spec.Kafka.Replicas == numberOfRequiredReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Number of replicas for apicurito.Spec.Size is not correct : Replicas - %v, Expected - %v", *&amqstreams.Spec.Kafka.Replicas, numberOfRequiredReplicas)
+	}
+	return nil
+}

--- a/test/common/scale_up_replicas_apicurito.go
+++ b/test/common/scale_up_replicas_apicurito.go
@@ -1,0 +1,140 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+	"time"
+
+	apicuritov1alpha1 "github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	numberOfApicuritoReplicas  = 2 //size in reconciler
+	scaleUpApicuritoReplicas   = 3
+	scaleDownApicuritoReplicas = 1
+	apicuritoName              = "apicurito"
+	apicuritoNamespace         = NamespacePrefix + "apicurito"
+	retryIntervalApicurito     = time.Second * 20
+	timeoutApicurito           = time.Minute * 7
+	requestURLApicturito       = "/apis/apicur.io/v1alpha1"
+	kindApicurito              = "apicuritos"
+)
+
+func TestReplicasInApicurito(t TestingTB, ctx *TestingContext) {
+
+	apicuritoCR, err := getApicurito(ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to get Apicurito : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas are set")
+	if err := checkNumberOfReplicasAgainstValueApicurito(apicuritoCR, ctx, int32(numberOfApicuritoReplicas), retryIntervalApicurito, timeoutApicurito, t); err != nil {
+		t.Fatalf("Incorrect number of replicas to start : %v", err)
+	}
+
+	apicuritoCR, err = updateApicurito(ctx, int32(scaleUpApicuritoReplicas), t)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueApicurito(apicuritoCR, ctx, int32(scaleUpApicuritoReplicas), retryIntervalApicurito, timeoutApicurito, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	apicuritoCR, err = updateApicurito(ctx, int32(scaleDownApicuritoReplicas), t)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueApicurito(apicuritoCR, ctx, int32(numberOfApicuritoReplicas), retryIntervalApicurito, timeoutApicurito, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	t.Log("Checking replicas are ready")
+	if err := checkReplicasAreReady(ctx, t, int32(numberOfApicuritoReplicas)); err != nil {
+		t.Fatalf("Replicas weren't ready within timeout")
+	}
+
+}
+
+func checkReplicasAreReady(dynClient *TestingContext, t TestingTB, replicas int32) error {
+
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+
+		deployment, err := dynClient.KubeClient.AppsV1().Deployments(apicuritoNamespace).Get(context.TODO(), apicuritoName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Failed to get Deployment %s in namespace %s with error: %s", apicuritoName, apicuritoNamespace, err)
+		}
+		if deployment.Status.ReadyReplicas == replicas {
+			t.Logf("Replicas Ready %v", deployment.Status.ReadyReplicas)
+			return true, nil
+		}
+		return false, fmt.Errorf("%v", deployment.Status.ReadyReplicas)
+	})
+	if err != nil {
+		return fmt.Errorf("Number of replicas for apicurito.Spec.Size is not correct : Replicas - %v, Expected - %v", err, replicas)
+	}
+	return nil
+}
+
+func getApicurito(dynClient k8sclient.Client) (apicuritov1alpha1.Apicurito, error) {
+	apicuritoCR := &apicuritov1alpha1.Apicurito{}
+
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: apicuritoName, Namespace: apicuritoNamespace}, apicuritoCR); err != nil {
+		return *apicuritoCR, err
+	}
+
+	return *apicuritoCR, nil
+}
+
+func updateApicurito(ctx *TestingContext, replicas int32, t TestingTB) (apicuritov1alpha1.Apicurito, error) {
+
+	replica := fmt.Sprintf(`{
+		"apiVersion": "apicur.io/v1alpha1",
+		"kind": "Apicurito",
+		"spec": {
+			"size": %[1]v
+		}
+	}`, replicas)
+
+	replicaBytes := []byte(replica)
+
+	request := ctx.ExtensionClient.RESTClient().Patch(types.MergePatchType).
+		Resource(kindApicurito).
+		Name(apicuritoName).
+		Namespace(apicuritoNamespace).
+		RequestURI(requestURLApicturito).Body(replicaBytes).Do(context.TODO())
+	_, err := request.Raw()
+
+	apicuritoCR, err := getApicurito(ctx.Client)
+	if err != nil {
+		return apicuritoCR, err
+	}
+
+	return apicuritoCR, nil
+}
+
+func checkNumberOfReplicasAgainstValueApicurito(apicuritoCR apicuritov1alpha1.Apicurito, ctx *TestingContext, numberOfRequiredReplicas int32, retryInterval, timeout time.Duration, t TestingTB) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		apicuritoCR, err = getApicurito(ctx.Client)
+		if err != nil {
+			t.Fatalf("failed to get Apicurito : %v", err)
+		}
+		if *&apicuritoCR.Spec.Size == numberOfRequiredReplicas {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Number of replicas for apicurito.Spec.Size is not correct : Replicas - %v, Expected - %v", *&apicuritoCR.Spec.Size, numberOfRequiredReplicas)
+	}
+	return nil
+}

--- a/test/common/scale_up_replicas_rhsso.go
+++ b/test/common/scale_up_replicas_rhsso.go
@@ -1,0 +1,168 @@
+package common
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	rhssoName     = "rhsso"
+	userSSOName   = "rhssouser"
+	requestURLSSO = "/apis/keycloak.org/v1alpha1"
+	kindSSO       = "Keycloaks"
+)
+
+func TestReplicasInRHSSO(t TestingTB, ctx *TestingContext) {
+	inst, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI instance %v", err)
+	}
+
+	rhssoConfig := config.NewRHSSO(map[string]string{})
+	numberOfRhssoReplicas := rhssoConfig.GetReplicasConfig(inst)
+	checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), numberOfRhssoReplicas)
+
+}
+
+func TestReplicasInUserSSO(t TestingTB, ctx *TestingContext) {
+	inst, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI instance %v", err)
+	}
+
+	userRhssoConfig := config.NewRHSSO(map[string]string{})
+	numberOfUserRhssoReplicas := userRhssoConfig.GetReplicasConfig(inst)
+	checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), numberOfUserRhssoReplicas)
+}
+
+func checkScalingOfKeycloakReplicas(t TestingTB, ctx *TestingContext, keycloakCRName string, keycloakCRNamespace string, expectedReplicas int) {
+	scaleUpRhssoReplicas := expectedReplicas + 1
+	scaleDownRhssoReplicas := expectedReplicas - 1
+	keycloakCR, err := getKeycloakCR(ctx.Client, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("failed to get KeycloakCR : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, expectedReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas to start : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx, scaleUpRhssoReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, scaleUpRhssoReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx, scaleDownRhssoReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, expectedReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx, expectedReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas has been reset")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, expectedReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	t.Log("Checking replicas are ready")
+	if err := checkSSOReplicasAreReady(ctx, t, int32(expectedReplicas), keycloakCRNamespace, retryInterval, timeout); err != nil {
+		t.Fatalf("Replicas weren't ready within timeout")
+	}
+}
+
+func getKeycloakCR(dynClient k8sclient.Client, keycloakCRName string, keycloakCRNamespace string) (keycloakv1alpha1.Keycloak, error) {
+	keycloakCR := &keycloakv1alpha1.Keycloak{}
+
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: keycloakCRName, Namespace: keycloakCRNamespace}, keycloakCR); err != nil {
+		return *keycloakCR, err
+	}
+
+	return *keycloakCR, nil
+}
+
+func updateKeycloakCR(dynClient *TestingContext, replicas int, keycloakCRName string, keycloakCRNamespace string) (keycloakv1alpha1.Keycloak, error) {
+
+	replica := fmt.Sprintf(`{
+		"apiVersion": "keycloak.org/v1alpha1",
+		"kind": "Keycloak",
+		"spec": {
+			"instances": %[1]v
+		}
+	}`, replicas)
+
+	replicaBytes := []byte(replica)
+
+	request := dynClient.ExtensionClient.RESTClient().Patch(types.MergePatchType).
+		Resource(kindSSO).
+		Name(keycloakCRName).
+		Namespace(keycloakCRNamespace).
+		RequestURI(requestURLSSO).Body(replicaBytes).Do(goctx.TODO())
+	_, err := request.Raw()
+
+	keycloakCR, err := getKeycloakCR(dynClient.Client, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		return keycloakCR, err
+	}
+
+	return keycloakCR, nil
+}
+
+func checkNumberOfReplicasAgainstValueRhsso(keycloakCR keycloakv1alpha1.Keycloak, ctx *TestingContext, numberOfRequiredReplicas int, retryInterval, timeout time.Duration, t TestingTB) error {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		keycloakCR, err = getKeycloakCR(ctx.Client, keycloakCR.Name, keycloakCR.Namespace)
+		if err != nil {
+			t.Fatalf("failed to get KeycloakCR : %v", err)
+		}
+		if keycloakCR.Spec.Instances != numberOfRequiredReplicas {
+			t.Logf("Number of replicas for keycloakCR.Spec.Instances is not correct : Replicas - %v, Expected - %v", keycloakCR.Spec.Instances, numberOfRequiredReplicas)
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func checkSSOReplicasAreReady(dynClient *TestingContext, t TestingTB, replicas int32, keycloakCRNamespace string, retryInterval, timeout time.Duration) error {
+
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+
+		statefulSet, err := dynClient.KubeClient.AppsV1().StatefulSets(keycloakCRNamespace).Get(context.TODO(), "keycloak", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("failed to get Statefulset %s in namespace %s with error: %s", "Keycloak", keycloakCRNamespace, err)
+		}
+		if statefulSet.Status.ReadyReplicas != replicas {
+			t.Logf("replicas ready %v", statefulSet.Status.ReadyReplicas)
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("number of replicas for sso.Spec.replicas is not correct : Replicas - %v, Expected - %v", err, replicas)
+	}
+	return nil
+}

--- a/test/common/scale_up_replicas_threescale.go
+++ b/test/common/scale_up_replicas_threescale.go
@@ -1,0 +1,261 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+
+	threescalev1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	name             = "3scale"
+	retryInterval    = time.Second * 20
+	timeout          = time.Minute * 7
+	requestURL3scale = "/apis/apps.3scale.net/v1alpha1"
+	kind             = "APIManagers"
+)
+
+var (
+	threeScaleDeploymentConfigs = map[string]string{
+		"apicast-production": "apicastProd",
+		"apicast-staging":    "apicastStage",
+		"backend-cron":       "backendCron",
+		"backend-listener":   "backendListener",
+		"backend-worker":     "backendWorker",
+		"system-app":         "systemApp",
+		"system-sidekiq":     "systemSidekiq",
+		"zync":               "zyncApp",
+		"zync-que":           "zyncQue",
+	}
+)
+
+func TestReplicasInThreescale(t TestingTB, ctx *TestingContext) {
+
+	apim, err := getAPIManager(ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to get APIManager : %v", err)
+	}
+	inst, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI instance %v", err)
+	}
+
+	threescaleConfig := config.NewThreeScale(map[string]string{})
+	replicas := threescaleConfig.GetReplicasConfig(inst)
+
+	scaleUpReplicas := map[string]int64{}
+	for k, v := range replicas {
+		scaleUpReplicas[k] = v + 1
+	}
+	scaleDownReplicas := map[string]int64{}
+	for k, v := range replicas {
+		scaleDownReplicas[k] = v - 1
+	}
+
+	t.Log("Checking correct number of replicas are set")
+	if err := checkNumberOfReplicasAgainstValue(apim, ctx, replicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas to start : %v", err)
+	}
+
+	apim, err = updateAPIManager(ctx, scaleUpReplicas)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValue(apim, ctx, scaleUpReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	apim, err = updateAPIManager(ctx, scaleDownReplicas)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValue(apim, ctx, replicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	apim, err = updateAPIManager(ctx, replicas)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas has been reset")
+	if err := checkNumberOfReplicasAgainstValue(apim, ctx, replicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	if err := check3ScaleReplicasAreReady(ctx, t, replicas, retryInterval, timeout); err != nil {
+		t.Fatalf("Replicas not Ready within timeout: %v", err)
+	}
+
+}
+
+func getAPIManager(dynClient k8sclient.Client) (threescalev1.APIManager, error) {
+	apim := &threescalev1.APIManager{}
+
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: GetPrefixedNamespace("3scale")}, apim); err != nil {
+		return *apim, err
+	}
+	return *apim, nil
+}
+
+func updateAPIManager(dynClient *TestingContext, replicas map[string]int64) (threescalev1.APIManager, error) {
+
+	replica := fmt.Sprintf(
+		`{
+			"apiVersion": "apps.3scale.net/v1alpha1",
+			"kind": "APIManager",
+			"spec": {
+				"system": {
+					"appSpec": {
+						"replicas": %v
+					},
+					"sidekiqSpec": {
+						"replicas": %v
+					}
+				},
+				"apicast": {
+					"productionSpec": {
+						"replicas": %v
+					},
+					"stagingSpec": {
+						"replicas": %v
+					}
+				},
+				"backend": {
+					"listenerSpec": {
+						"replicas": %v
+					},
+					"cronSpec": {
+						"replicas": %v
+					},
+					"workerSpec": {
+						"replicas": %v
+					}
+				},
+				"zync": {
+					"appSpec": {
+						"replicas": %v
+					},
+					"queSpec": {
+						"replicas": %v
+					}
+				}
+			}
+		}`,
+		replicas["systemApp"],
+		replicas["systemSidekiq"],
+		replicas["apicastProd"],
+		replicas["apicastStage"],
+		replicas["backendListener"],
+		replicas["backendCron"],
+		replicas["backendWorker"],
+		replicas["zyncApp"],
+		replicas["zyncQue"],
+	)
+
+	replicaBytes := []byte(replica)
+
+	request := dynClient.ExtensionClient.RESTClient().Patch(types.MergePatchType).
+		Resource(kind).
+		Name(name).
+		Namespace(GetPrefixedNamespace("3scale")).
+		RequestURI(requestURL3scale).Body(replicaBytes).Do(goctx.TODO())
+	_, err := request.Raw()
+
+	apim, err := getAPIManager(dynClient.Client)
+	if err != nil {
+		return apim, err
+	}
+
+	return apim, nil
+}
+
+func checkNumberOfReplicasAgainstValue(apim threescalev1.APIManager, ctx *TestingContext, replicas map[string]int64, retryInterval, timeout time.Duration, t TestingTB) error {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		apim, err = getAPIManager(ctx.Client)
+		if err != nil {
+			t.Fatalf("failed to get APIManager : %v", err)
+		}
+
+		if *apim.Spec.System.AppSpec.Replicas != replicas["systemApp"] {
+			t.Logf("Number of replicas for apim.Spec.System.AppSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.System.AppSpec.Replicas, replicas["systemApp"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.System.SidekiqSpec.Replicas != replicas["systemSidekiq"] {
+			t.Logf("Number of replicas for apim.Spec.System.SidekiqSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.System.SidekiqSpec.Replicas, replicas["systemSidekiq"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Apicast.ProductionSpec.Replicas != replicas["apicastProd"] {
+			t.Logf("Number of replicas for apim.Spec.Apicast.ProductionSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Apicast.ProductionSpec.Replicas, replicas["apicastProd"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Apicast.StagingSpec.Replicas != replicas["apicastStage"] {
+			t.Logf("Number of replicas for apim.Spec.Apicast.StagingSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Apicast.StagingSpec.Replicas, replicas["apicastStage"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Backend.ListenerSpec.Replicas != replicas["backendListener"] {
+			t.Logf("Number of replicas for apim.Spec.Backend.ListenerSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.ListenerSpec.Replicas, replicas["backendListener"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Backend.WorkerSpec.Replicas != replicas["backendWorker"] {
+			t.Logf("Number of replicas for apim.Spec.Backend.WorkerSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.WorkerSpec.Replicas, replicas["backendWorker"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Backend.CronSpec.Replicas != replicas["backendCron"] {
+			t.Logf("Number of replicas for apim.Spec.Backend.CronSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.CronSpec.Replicas, replicas["backendCron"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Zync.AppSpec.Replicas != replicas["zyncApp"] {
+			t.Logf("Number of replicas for apim.Spec.Zync.AppSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Zync.AppSpec.Replicas, replicas["zyncApp"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		if *apim.Spec.Zync.QueSpec.Replicas != replicas["zyncQue"] {
+			t.Logf("Number of replicas for apim.Spec.Zync.QueSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Zync.QueSpec.Replicas, replicas["zyncQue"])
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func check3ScaleReplicasAreReady(ctx *TestingContext, t TestingTB, replicas map[string]int64, retryInterval, timeout time.Duration) error {
+
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+
+		for name, replicasID := range threeScaleDeploymentConfigs {
+			deploymentConfig := &appsv1.DeploymentConfig{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: GetPrefixedNamespace("3scale")}}
+
+			err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: GetPrefixedNamespace("3scale")}, deploymentConfig)
+			if err != nil {
+				t.Errorf("failed to get DeploymentConfig %s in namespace %s with error: %s", name, GetPrefixedNamespace("3scale"), err)
+			}
+
+			if deploymentConfig.Status.Replicas != int32(replicas[replicasID]) {
+				t.Logf("%s replicas ready %v, expected %v ", name, deploymentConfig.Status.ReadyReplicas, replicas[replicasID])
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}

--- a/test/common/sendgrid_credentials_valid.go
+++ b/test/common/sendgrid_credentials_valid.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"context"
+	"crypto/tls"
+	"net/smtp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSendgridCredentialsAreValid(t TestingTB, ctx *TestingContext) {
+	// Get SMTP secret from rhmi-operator namespace
+	kc := ctx.KubeClient
+	smtpSecret, err := kc.CoreV1().Secrets(RHMIOperatorNamespace).Get(context.TODO(), NamespacePrefix+"smtp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("Failed to get an SMTP secret", err)
+	}
+
+	username, password, host, port :=
+		string(smtpSecret.Data["username"]),
+		string(smtpSecret.Data["password"]),
+		string(smtpSecret.Data["host"]),
+		string(smtpSecret.Data["port"])
+
+	if host != "smtp.sendgrid.net" {
+		t.Skip("Skipping the test, because the credentials were not set by a Sendgrid service")
+	}
+
+	// Test if SMTP credentials are valid using smtp.Auth method
+	auth := smtp.PlainAuth("", username, password, host)
+	client, err := smtp.Dial(host + ":" + port)
+	if err != nil {
+		t.Fatal("Failed to create an SMTP client", err)
+	}
+	err = client.StartTLS(&tls.Config{ServerName: host})
+	if err != nil {
+		t.Fatal("Failed to encrypt the communication between an SMTP client and a server", err)
+	}
+	err = client.Auth(auth)
+	if err != nil {
+		t.Fatal("Failed to authenticate an SMTP client with provided credentials", err)
+	}
+}

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -1,0 +1,340 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	routev1 "github.com/openshift/api/route/v1"
+	"golang.org/x/net/publicsuffix"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	cached "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/remotecommand"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewTestingContext(kubeConfig *rest.Config) (*TestingContext, error) {
+	kubeclient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the kubeclient: %v", err)
+	}
+
+	apiextensions, err := clientset.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the apiextension client: %v", err)
+	}
+
+	if err := extscheme.AddToScheme(scheme.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to add api extensions scheme to runtime scheme: (%v)", err)
+	}
+	if err := routev1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to add route scheme to runtime scheme: (%v)", err)
+	}
+	if err := rhmiv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to add integreatly scheme to runtime scheme: (%v)", err)
+	}
+	if err := rhmiv1alpha1.AddToSchemes.AddToScheme(scheme.Scheme); err != nil {
+		return nil, fmt.Errorf("failed to add integreatly scheme to runtime scheme: (%v)", err)
+	}
+
+	cachedDiscoveryClient := cached.NewMemCacheClient(kubeclient.Discovery())
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	restMapper.Reset()
+
+	dynClient, err := k8sclient.New(kubeConfig, k8sclient.Options{Scheme: scheme.Scheme, Mapper: restMapper})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the dynamic client: %v", err)
+	}
+
+	urlToCheck := kubeConfig.Host
+	consoleUrl, err := getConsoleRoute(dynClient)
+	if err != nil {
+		return nil, err
+	}
+	if consoleUrl != nil {
+		// use the console url if we can as when the tests are executed inside a pod, the kubeConfig.Host value is the ip address of the pod
+		urlToCheck = *consoleUrl
+	}
+
+	selfSignedCerts, err := HasSelfSignedCerts(fmt.Sprintf("https://%s", urlToCheck), http.DefaultClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine self-signed certs status on cluster: %w", err)
+	}
+
+	httpClient, err := NewTestingHTTPClient(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create testing http client: %v", err)
+	}
+
+	return &TestingContext{
+		Client:          dynClient,
+		KubeConfig:      kubeConfig,
+		KubeClient:      kubeclient,
+		ExtensionClient: apiextensions,
+		HttpClient:      httpClient,
+		SelfSignedCerts: selfSignedCerts,
+	}, nil
+}
+
+func NewTestingHTTPClient(kubeConfig *rest.Config) (*http.Client, error) {
+	selfSignedCerts, err := HasSelfSignedCerts(kubeConfig.Host, http.DefaultClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine self-signed certs status on cluster: %w", err)
+	}
+
+	// Create the http client with a cookie jar
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new cookie jar: %v", err)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: selfSignedCerts},
+	}
+
+	httpClient := &http.Client{
+		Jar:           jar,
+		Transport:     transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return nil },
+	}
+
+	return httpClient, nil
+}
+
+func HasSelfSignedCerts(url string, httpClient *http.Client) (bool, error) {
+	if _, err := httpClient.Get(url); err != nil {
+		if _, ok := errors.Unwrap(err).(x509.UnknownAuthorityError); !ok {
+			return false, fmt.Errorf("error while performing self-signed certs test request: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func getConsoleRoute(client k8sclient.Client) (*string, error) {
+	route := &routev1.Route{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: OpenShiftConsoleRoute, Namespace: OpenShiftConsoleNamespace}, route); err != nil {
+		return nil, err
+	}
+	if len(route.Status.Ingress) > 0 {
+		return &route.Status.Ingress[0].Host, nil
+	}
+	return nil, nil
+}
+
+func GetInstallType(config *rest.Config) (string, error) {
+
+	context, err := NewTestingContext(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create testing context %s", err)
+	}
+	rhmi, err := GetRHMI(context.Client, true)
+
+	if err != nil {
+		return "", err
+	}
+
+	return rhmi.Spec.Type, nil
+}
+
+func GetRHMI(client k8sclient.Client, failNotExist bool) (*rhmiv1alpha1.RHMI, error) {
+	installationList := &rhmiv1alpha1.RHMIList{}
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(RHMIOperatorNamespace),
+	}
+	err := client.List(context.TODO(), installationList, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(installationList.Items) == 0 && failNotExist == true {
+		return nil, fmt.Errorf("rhmi CRs does not exist: %v namespace: '%v', list: %v", err, RHMIOperatorNamespace, installationList)
+	}
+	if len(installationList.Items) == 0 && failNotExist == false {
+		return nil, nil
+	}
+	if len(installationList.Items) != 1 {
+		return nil, fmt.Errorf("Unexpected number of rhmi CRs: %w", err)
+	}
+	return &installationList.Items[0], nil
+}
+
+func GetHappyPathTestCases(installType string) []TestCase {
+	testCases := []TestCase{}
+	for _, testSuite := range HAPPY_PATH_TESTS {
+		for _, tsInstallType := range testSuite.InstallType {
+			if string(tsInstallType) == installType {
+				testCases = append(testCases, testSuite.TestCases...)
+			}
+		}
+	}
+
+	return testCases
+}
+
+func getTimeStampPrefix() string {
+	t := time.Now().UTC()
+	return fmt.Sprintf("%d_%02d_%02dT%02d_%02d_%02d",
+		t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second())
+}
+
+func execToPod(command string, podName string, namespace string, container string, ctx *TestingContext) (string, error) {
+	req := ctx.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container)
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   strings.Fields(command),
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error in Stream: %v", err)
+	}
+	return stdout.String(), nil
+}
+
+// Is the cluster using on cluster or external storage
+func isClusterStorage(ctx *TestingContext) (bool, error) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		return true, fmt.Errorf("error getting RHMI CR: %v", err)
+	}
+
+	if rhmi.Spec.UseClusterStorage == "true" {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Common function to perform CRUDL and verifying their expected permissions
+func verifyCRUDLPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient, expectedPermission ExpectedPermissions) {
+	// Perform LIST Request
+	resp, err := openshiftClient.DoOpenshiftGetRequest(expectedPermission.ListPath)
+
+	if err != nil {
+		t.Errorf("failed to perform LIST request with error : %s", err)
+	}
+
+	if resp.StatusCode != expectedPermission.ExpectedListStatusCode {
+		t.Skip("Skipping due to a flaky behavior on managed-api addon install, JIRA: https://issues.redhat.com/browse/INTLY-10156")
+		// t.Errorf("unexpected response from LIST request, expected %d status but got: %v", expectedPermission.ExpectedListStatusCode, resp)
+	}
+
+	// Perform CREATE Request
+	bodyBytes, err := json.Marshal(expectedPermission.ObjectToCreate)
+
+	if err != nil {
+		t.Errorf("failed to marshal object to json for create request: %s", err)
+	}
+
+	resp, err = openshiftClient.DoOpenshiftPostRequest(expectedPermission.ListPath, bodyBytes)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Errorf("failed to perform CREATE request with error : %s", err)
+	}
+
+	if resp.StatusCode != expectedPermission.ExpectedCreateStatusCode {
+		t.Errorf("unexpected response from CREATE request, expected %d status but got: %v", expectedPermission.ExpectedCreateStatusCode, resp)
+	}
+
+	// Perform GET Request
+	resp, err = openshiftClient.DoOpenshiftGetRequest(expectedPermission.GetPath)
+
+	if err != nil {
+		t.Errorf("failed to perform GET request with error : %s", err)
+	}
+
+	if resp.StatusCode != expectedPermission.ExpectedReadStatusCode {
+		t.Errorf("unexpected response from GET request, expected %d status but got: %v", expectedPermission.ExpectedReadStatusCode, resp)
+	}
+
+	// Perform UPDATE Request
+	bodyBytes, err = ioutil.ReadAll(resp.Body) // Use response from GET
+
+	if err != nil {
+		t.Errorf("failed to read response body for update request: %s", err)
+	}
+
+	resp, err = openshiftClient.DoOpenshiftPutRequest(expectedPermission.GetPath, bodyBytes)
+
+	if err != nil {
+		t.Errorf("failed to perform UPDATE request with error : %s", err)
+	}
+
+	if resp.StatusCode != expectedPermission.ExpectedUpdateStatusCode {
+		t.Errorf("unexpected response from UPDATE request, expected %d status but got: %v", expectedPermission.ExpectedUpdateStatusCode, resp)
+	}
+
+	// Perform DELETE Request
+	resp, err = openshiftClient.DoOpenshiftDeleteRequest(expectedPermission.GetPath)
+
+	if err != nil {
+		t.Errorf("failed to perform DELETE request with error : %s", err)
+	}
+
+	if resp.StatusCode != expectedPermission.ExpectedDeleteStatusCode {
+		t.Errorf("unexpected response from DELETE request, expected %d status but got: %v", expectedPermission.ExpectedDeleteStatusCode, resp)
+	}
+
+	// Close the response body
+	err = resp.Body.Close()
+	if err != nil {
+		t.Errorf("failed to close response body: %s", err)
+	}
+}
+
+func GetIDPBasedTestCases(installType string) []TestCase {
+	testCases := []TestCase{}
+	for _, testSuite := range IDP_BASED_TESTS {
+		for _, tsInstallType := range testSuite.InstallType {
+			if string(tsInstallType) == installType {
+				testCases = append(testCases, testSuite.TestCases...)
+			}
+		}
+	}
+	return testCases
+}

--- a/test/common/subscription_install_plan.go
+++ b/test/common/subscription_install_plan.go
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"context"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	expectedApprovalStrategy = coreosv1alpha1.ApprovalManual
+)
+
+func commonSubscriptionsToCheck() []SubscriptionCheck {
+	return []SubscriptionCheck{
+		{
+			Name:      constants.MonitoringSubscriptionName,
+			Namespace: MonitoringOperatorNamespace,
+		},
+		{
+			Name:      constants.RHSSOSubscriptionName,
+			Namespace: RHSSOUserOperatorNamespace,
+		},
+		{
+			Name:      constants.RHSSOSubscriptionName,
+			Namespace: RHSSOOperatorNamespace,
+		},
+		{
+			Name:      constants.ThreeScaleSubscriptionName,
+			Namespace: ThreeScaleOperatorNamespace,
+		},
+		{
+			Name:      constants.CloudResourceSubscriptionName,
+			Namespace: CloudResourceOperatorNamespace,
+		},
+	}
+}
+
+// Applicable to rhmi 2 install types
+func rhmi2SubscriptionsToCheck() []SubscriptionCheck {
+	return []SubscriptionCheck{
+		{
+			Name:      constants.AMQOnlineSubscriptionName,
+			Namespace: AMQOnlineOperatorNamespace,
+		},
+		{
+			Name:      constants.ApicuritoSubscriptionName,
+			Namespace: ApicuritoOperatorNamespace,
+		},
+		{
+			Name:      constants.CodeReadySubscriptionName,
+			Namespace: CodeReadyOperatorNamespace,
+		},
+		{
+			Name:      constants.FuseSubscriptionName,
+			Namespace: FuseOperatorNamespace,
+		},
+		{
+			Name:      constants.UPSSubscriptionName,
+			Namespace: UPSOperatorNamespace,
+		},
+		{
+			Name:      constants.SolutionExplorerSubscriptionName,
+			Namespace: SolutionExplorerOperatorNamespace,
+		},
+	}
+}
+func managedApiSubscriptionsToCheck() []SubscriptionCheck {
+	return []SubscriptionCheck{
+		{
+			Name:      constants.Marin3rSubscriptionName,
+			Namespace: Marin3rOperatorNamespace,
+		},
+		{
+			Name:      constants.GrafanaSubscriptionName,
+			Namespace: CustomerGrafanaNamespace,
+		},
+	}
+}
+
+func TestSubscriptionInstallPlanType(t TestingTB, ctx *TestingContext) {
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get the RHMI: %s", err)
+	}
+	subscriptionsToCheck := getSubscriptionsToCheck(rhmi.Spec.Type)
+
+	for _, subscription := range subscriptionsToCheck {
+		// Check subscription install plan approval strategy
+		sub := &coreosv1alpha1.Subscription{}
+		err := ctx.Client.Get(context.TODO(), k8sclient.ObjectKey{Name: subscription.Name, Namespace: subscription.Namespace}, sub)
+		if err != nil {
+			t.Errorf("Error getting subscription %s in ns %s: %s", subscription.Name, subscription.Namespace, err)
+			continue
+		}
+
+		if sub.Spec.InstallPlanApproval != expectedApprovalStrategy {
+			t.Errorf("Expected %s approval for %s subscription but got %s", expectedApprovalStrategy, subscription, sub.Spec.InstallPlanApproval)
+			continue
+		}
+
+		// Check all install plan approvals in namespace
+		installPlans := &coreosv1alpha1.InstallPlanList{}
+		err = ctx.Client.List(context.TODO(), installPlans, &k8sclient.ListOptions{
+			Namespace: subscription.Namespace,
+		})
+
+		if err != nil {
+			t.Errorf("Error getting install plans for %s namespace: %s", subscription.Namespace, err)
+			continue
+		}
+
+		if len(installPlans.Items) == 0 {
+			t.Errorf("Expected at least 1 install plan in %s namespace but got 0", subscription.Namespace)
+			continue
+		}
+
+		for _, installPlan := range installPlans.Items {
+			if installPlan.Spec.Approval != expectedApprovalStrategy {
+				t.Errorf("Expected %s approval for install plan in %s namespace but got %s", expectedApprovalStrategy, subscription.Namespace, installPlan.Spec.Approval)
+			}
+		}
+	}
+}
+
+func getSubscriptionsToCheck(installType string) []SubscriptionCheck {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(commonSubscriptionsToCheck(), managedApiSubscriptionsToCheck()...)
+	} else {
+		return append(commonSubscriptionsToCheck(), rhmi2SubscriptionsToCheck()...)
+	}
+}

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -1,0 +1,774 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	v12 "github.com/openshift/api/authorization/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/route/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	TestingIDPRealm                = "testing-idp"
+	defaultDedicatedAdminName      = "customer-admin"
+	defaultNumberOfTestUsers       = 2
+	defaultNumberOfDedicatedAdmins = 2
+	defaultSecret                  = "rhmiForeva"
+	DefaultTestUserName            = "test-user"
+	DefaultPassword                = "Password1"
+)
+
+var (
+	keycloakClientName           = fmt.Sprintf("%s-client", TestingIDPRealm)
+	keycloakClientNamespace      = RHSSOProductNamespace
+	clusterOauthClientSecretName = fmt.Sprintf("idp-%s", TestingIDPRealm)
+	idpCAName                    = fmt.Sprintf("idp-ca-%s", TestingIDPRealm)
+)
+
+type TestUser struct {
+	UserName  string
+	FirstName string
+	LastName  string
+}
+
+// creates testing idp
+func createTestingIDP(t TestingTB, ctx context.Context, client dynclient.Client, kubeConfig *rest.Config, hasSelfSignedCerts bool) error {
+
+	// checks if the IDP is created already
+	if hasIDPCreated(ctx, client, t) {
+		t.Log("not creating IDP, it's already created")
+		return nil
+	}
+
+	rhmiCR, err := GetRHMI(client, true)
+	if err != nil {
+		return fmt.Errorf("error occurred while getting rhmi cr: %w", err)
+	}
+	masterURL := rhmiCR.Spec.MasterURL
+
+	// create dedicated admins group is it doesnt exist
+	if !hasDedicatedAdminGroup(ctx, client) {
+		if err := setupDedicatedAdminGroup(ctx, client); err != nil {
+			return fmt.Errorf("error occurred while creating dedicated admin group: %w", err)
+		}
+	}
+
+	// get oauth route
+	oauthRoute := &v1.Route{}
+	if err := client.Get(ctx, types.NamespacedName{Name: resources.OpenshiftOAuthRouteName, Namespace: resources.OpenshiftAuthenticationNamespace}, oauthRoute); err != nil {
+		return fmt.Errorf("error occurred while getting Openshift Oauth Route: %w ", err)
+	}
+	// create keycloak client secret
+	if err := createClientSecret(ctx, client, []byte(defaultSecret)); err != nil {
+		return fmt.Errorf("error occurred while setting up testing idp client secret: %w", err)
+	}
+
+	// create keycloak realm
+	if err := createKeycloakRealm(ctx, client, rhmiCR.Name); err != nil {
+		return fmt.Errorf("error occurred while setting up keycloak realm: %w", err)
+	}
+
+	// Delete current client to ensure new created client secret is correct
+	if err := deleteKeycloakClient(ctx, client); err != nil {
+		return err
+	}
+
+	// create keycloak client
+	if err := createKeycloakClient(ctx, client, oauthRoute.Spec.Host, rhmiCR.Name); err != nil {
+		return fmt.Errorf("error occurred while setting up keycloak client: %w", err)
+	}
+
+	if err := ensureKeycloakClientIsReady(ctx, client); err != nil {
+		return fmt.Errorf("error occurred while waiting on keycloak client: %w", err)
+	}
+
+	// create keycloak rhmi developer users
+	if err := createKeycloakUsers(ctx, client, rhmiCR.Name); err != nil {
+		return fmt.Errorf("error occurred while setting up keycloak users: %w", err)
+	}
+
+	if hasSelfSignedCerts {
+		if err := setupIDPConfig(ctx, client); err != nil {
+			return fmt.Errorf("error occurred while updating openshift config: %w", err)
+		}
+	}
+
+	// create idp in cluster oauth
+	if err := addIDPToOauth(ctx, client, hasSelfSignedCerts); err != nil {
+		return fmt.Errorf("error occurred while adding testing idp to cluster config: %w", err)
+	}
+
+	// add users to dedicated admin users
+	if err := addDedicatedAdminUsers(ctx, client, defaultNumberOfDedicatedAdmins); err != nil {
+		return fmt.Errorf("error occurred while adding users to dedicated admin group: %w", err)
+	}
+
+	// ensure oauth has redeployed
+	if err := waitForOauthDeployment(ctx, client); err != nil {
+		return fmt.Errorf("error occurred while waiting for oauth deployment: %w", err)
+	}
+	// ensure the IDP is available in OpenShift
+	err = wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		// Use a temporary HTTP client to avoid polluting testing client
+		tempHTTPClient, err := NewTestingHTTPClient(kubeConfig)
+		if err != nil {
+			return false, fmt.Errorf("failed to create temporary client for idp setup: %w", err)
+		}
+
+		dedicatedAdminUsername := fmt.Sprintf("%s%02d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins)
+		authErr := resources.DoAuthOpenshiftUser(fmt.Sprintf("https://%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, tempHTTPClient, TestingIDPRealm, t)
+		if authErr != nil {
+			t.Logf("Error while checking IDP is setup, retrying: %+v", authErr)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check for openshift idp: %w", err)
+	}
+	return nil
+}
+
+func waitForOauthDeployment(ctx context.Context, client dynclient.Client) error {
+	err := wait.PollImmediate(time.Second*5, time.Minute*1, func() (done bool, err error) {
+		oauthDeployment := &appsv1.Deployment{}
+		if err := client.Get(ctx, types.NamespacedName{Name: "oauth-openshift", Namespace: "openshift-authentication"}, oauthDeployment); err != nil {
+			return true, fmt.Errorf("error occurred while getting dedicated admin group")
+		}
+
+		if oauthDeployment.Status.AvailableReplicas > 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error occurred while polling oauth deployment: %w", err)
+	}
+	return nil
+}
+
+// add users to dedicated admin users
+func addDedicatedAdminUsers(ctx context.Context, client dynclient.Client, numberOfAdmins int) error {
+
+	// populate admin users
+	var adminUsers []string
+	postfix := 1
+	for postfix <= numberOfAdmins {
+		user := fmt.Sprintf("%s%02d", defaultDedicatedAdminName, postfix)
+		adminUsers = append(adminUsers, user)
+		postfix++
+	}
+
+	err := createOrUpdateDedicatedAdminGroupCR(ctx, client, adminUsers)
+	if err != nil {
+		return fmt.Errorf("error occurred while creating or updating dedicated admin group: %w", err)
+	}
+
+	return nil
+}
+
+func createOrUpdateDedicatedAdminGroupCR(ctx context.Context, client dynclient.Client, adminUsers []string) error {
+	dedicatedAdminGroup := &userv1.Group{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "dedicated-admins"}, dedicatedAdminGroup); err != nil {
+		return fmt.Errorf("error occurred while getting dedicated admin group")
+	}
+
+	// add admin users to group
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, dedicatedAdminGroup, func() error {
+		for _, user := range adminUsers {
+			if !contains(dedicatedAdminGroup.Users, user) {
+				dedicatedAdminGroup.Users = append(dedicatedAdminGroup.Users, user)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// create idp config with self signed cert
+func setupIDPConfig(ctx context.Context, client dynclient.Client) error {
+	routerSecret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "router-ca", Namespace: "openshift-ingress-operator"}, routerSecret); err != nil {
+		return fmt.Errorf("error occurred while getting router ca: %w", err)
+	}
+	tlsCrt := routerSecret.Data["tls.crt"]
+
+	idpConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      idpCAName,
+			Namespace: "openshift-config",
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, idpConfigMap, func() error {
+		if idpConfigMap.Data == nil {
+			idpConfigMap.Data = map[string]string{}
+		}
+		idpConfigMap.Data["ca.crt"] = string(tlsCrt)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating openshift cluster oauth: %w", err)
+	}
+	return nil
+}
+
+// add idp to cluster oauth
+func addIDPToOauth(ctx context.Context, client dynclient.Client, hasSelfSignedCerts bool) error {
+	// setup identity provider ca name
+	identityProviderCA := ""
+	if hasSelfSignedCerts {
+		identityProviderCA = idpCAName
+	}
+
+	clusterOauth := &configv1.OAuth{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, clusterOauth); err != nil {
+		return fmt.Errorf("error occurred while getting cluster oauth: %w", err)
+	}
+
+	keycloakRoute := &v1.Route{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "keycloak-edge", Namespace: RHSSOProductNamespace}, keycloakRoute); err != nil {
+		return fmt.Errorf("error occurred while getting Keycloak Edge Route: %w ", err)
+	}
+	identityProviderIssuer := fmt.Sprintf("https://%s/auth/realms/%s", keycloakRoute.Spec.Host, TestingIDPRealm)
+
+	// check if identity providers is nil or contains testing IDP
+	identityProviders := clusterOauth.Spec.IdentityProviders
+	idpAlreadySetUpByScript := false
+	idpIndex := 0
+	if identityProviders != nil {
+		for index, providers := range identityProviders {
+			if providers.Name == TestingIDPRealm {
+				idpAlreadySetUpByScript = true
+				idpIndex = index
+				break
+			}
+		}
+	}
+
+	// create identity provider
+	testingIdentityProvider := &configv1.IdentityProvider{
+		Name:          TestingIDPRealm,
+		MappingMethod: "claim",
+		IdentityProviderConfig: configv1.IdentityProviderConfig{
+			Type: configv1.IdentityProviderTypeOpenID,
+			OpenID: &configv1.OpenIDIdentityProvider{
+				ClientID: "openshift",
+				ClientSecret: configv1.SecretNameReference{
+					Name: clusterOauthClientSecretName,
+				},
+				CA: configv1.ConfigMapNameReference{
+					Name: identityProviderCA,
+				},
+				Issuer: identityProviderIssuer,
+				Claims: configv1.OpenIDClaims{
+					Email: []string{
+						"email",
+					},
+					Name: []string{
+						"name",
+					},
+					PreferredUsername: []string{
+						"preferred_username",
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, clusterOauth, func() error {
+		if clusterOauth.Spec.IdentityProviders == nil {
+			clusterOauth.Spec.IdentityProviders = []configv1.IdentityProvider{}
+		}
+		// If idp is already set up - ensure using the correct client secret generated from test
+		if idpAlreadySetUpByScript {
+			clusterOauth.Spec.IdentityProviders[idpIndex].OpenID.ClientSecret.Name = clusterOauthClientSecretName
+		} else {
+			clusterOauth.Spec.IdentityProviders = append(clusterOauth.Spec.IdentityProviders, *testingIdentityProvider)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating openshift cluster oauth: %w", err)
+	}
+	return nil
+}
+
+// creates secret to be used by keycloak client
+func createClientSecret(ctx context.Context, client dynclient.Client, clientSecret []byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterOauthClientSecretName,
+			Namespace: "openshift-config",
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data["clientSecret"] = clientSecret
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating openshift client secret: %w", err)
+	}
+	return nil
+}
+
+// create rhmi developer keycloak users
+func createKeycloakUsers(ctx context.Context, client dynclient.Client, installationName string) error {
+	// populate users to be created
+	var testUsers []TestUser
+	postfix := 1
+	// build rhmi developer users
+	for postfix <= defaultNumberOfTestUsers {
+		user := TestUser{
+			UserName:  fmt.Sprintf("%s%02d", DefaultTestUserName, postfix),
+			FirstName: "Test",
+			LastName:  fmt.Sprintf("User %02d", postfix),
+		}
+		testUsers = append(testUsers, user)
+		postfix++
+	}
+	postfix = 1
+	// build dedicated admin users
+	for postfix <= defaultNumberOfDedicatedAdmins {
+		user := TestUser{
+			UserName:  fmt.Sprintf("%s%02d", defaultDedicatedAdminName, postfix),
+			FirstName: defaultDedicatedAdminName,
+			LastName:  fmt.Sprintf("User %02d", postfix),
+		}
+		testUsers = append(testUsers, user)
+		postfix++
+	}
+
+	err := createOrUpdateKeycloakUserCR(ctx, client, testUsers, installationName)
+	if err != nil {
+		return fmt.Errorf("error occurred while creating or updating keycloak user: %w", err)
+	}
+
+	return nil
+}
+
+func createOrUpdateKeycloakUserCR(ctx context.Context, client dynclient.Client, testUsers []TestUser, installationName string) error {
+	// create rhmi developer users from test users
+	for _, user := range testUsers {
+		keycloakUser := &v1alpha1.KeycloakUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", TestingIDPRealm, user.UserName),
+				Namespace: RHSSOProductNamespace,
+			},
+		}
+
+		_, err := controllerutil.CreateOrUpdate(ctx, client, keycloakUser, func() error {
+			keycloakUser.Annotations = map[string]string{
+				"integreatly-namespace": RHMIOperatorNamespace,
+				"integreatly-name":      installationName,
+			}
+			keycloakUser.Spec = v1alpha1.KeycloakUserSpec{
+				RealmSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"sso": TestingIDPRealm,
+					},
+				},
+				User: v1alpha1.KeycloakAPIUser{
+					ID:        keycloakUser.Spec.User.ID,
+					FirstName: user.FirstName,
+					LastName:  user.LastName,
+					UserName:  user.UserName,
+					Email:     fmt.Sprintf("%s@example.com", user.UserName),
+					ClientRoles: map[string][]string{
+						"account": {
+							"manage-account",
+							"view-profile",
+						},
+						"broker": {
+							"read-token",
+						},
+					},
+					EmailVerified: true,
+					Enabled:       true,
+					Credentials: []v1alpha1.KeycloakCredential{
+						{
+							Type:  "password",
+							Value: DefaultPassword,
+						},
+					},
+				},
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// polls the keycloak client until it is ready
+func ensureKeycloakClientIsReady(ctx context.Context, client dynclient.Client) error {
+	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		keycloakClient := &v1alpha1.KeycloakClient{}
+
+		if err := client.Get(ctx, types.NamespacedName{Name: keycloakClientName, Namespace: keycloakClientNamespace}, keycloakClient); err != nil {
+			return false, fmt.Errorf("error occurred while getting keycloak client")
+		}
+		if keycloakClient.Status.Ready {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error occurred while polling keycloak client: %w", err)
+	}
+	return nil
+}
+
+// creates keycloak client
+func createKeycloakClient(ctx context.Context, client dynclient.Client, oauthURL string, installationName string) error {
+	fullScopeAllowed := true
+	keycloakClient := &v1alpha1.KeycloakClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      keycloakClientName,
+			Namespace: keycloakClientNamespace,
+			Annotations: map[string]string{
+				"integreatly-namespace": RHMIOperatorNamespace,
+				"integreatly-name":      installationName,
+			},
+		},
+		Spec: v1alpha1.KeycloakClientSpec{
+			RealmSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"sso": TestingIDPRealm,
+				},
+			},
+			Client: &v1alpha1.KeycloakAPIClient{
+				// ID:                      "openshift",
+				ClientID:                "openshift",
+				Enabled:                 true,
+				ClientAuthenticatorType: "client-secret",
+				Secret:                  defaultSecret,
+				RootURL:                 fmt.Sprintf("https://%s", oauthURL),
+				RedirectUris: []string{
+					fmt.Sprintf("https://%s/oauth2callback/%s", oauthURL, TestingIDPRealm),
+				},
+				WebOrigins: []string{
+					fmt.Sprintf("https://%s", oauthURL),
+					fmt.Sprintf("https://%s/*", oauthURL),
+				},
+				StandardFlowEnabled:       true,
+				DirectAccessGrantsEnabled: true,
+				FullScopeAllowed:          &fullScopeAllowed,
+				ProtocolMappers: []v1alpha1.KeycloakProtocolMapper{
+					{
+						Config: map[string]string{
+							"access.token.claim":   "true",
+							"claim.name":           "given_name",
+							"id.token.claim":       "true",
+							"jsonType.label":       "String",
+							"user.attribute":       "firstName",
+							"userinfo.token.claim": "true",
+						},
+						ConsentRequired: true,
+						ConsentText:     "${givenName}",
+						Name:            "given name",
+						Protocol:        "openid-connect",
+						ProtocolMapper:  "oidc-usermodel-property-mapper",
+					},
+					{
+						Config: map[string]string{
+							"access.token.claim":   "true",
+							"id.token.claim":       "true",
+							"userinfo.token.claim": "true",
+						},
+						ConsentRequired: true,
+						ConsentText:     "${fullName}",
+						Name:            "full name",
+						Protocol:        "openid-connect",
+						ProtocolMapper:  "oidc-full-name-mapper",
+					},
+					{
+						Config: map[string]string{
+							"access.token.claim":   "true",
+							"claim.name":           "family_name",
+							"id.token.claim":       "true",
+							"jsonType.label":       "String",
+							"user.attribute":       "lastName",
+							"userinfo.token.claim": "true",
+						},
+						ConsentRequired: true,
+						ConsentText:     "${familyName}",
+						Name:            "family name",
+						Protocol:        "openid-connect",
+						ProtocolMapper:  "oidc-usermodel-property-mapper",
+					},
+					{
+						Config: map[string]string{
+							"attribute.name":       "Role",
+							"attribute.nameformat": "Basic",
+							"single":               "false",
+						},
+						ConsentText:    "${familyName}",
+						Name:           "role list",
+						Protocol:       "saml",
+						ProtocolMapper: "saml-role-list-mapper",
+					},
+					{
+						Config: map[string]string{
+							"access.token.claim":   "true",
+							"claim.name":           "email",
+							"id.token.claim":       "true",
+							"jsonType.label":       "String",
+							"user.attribute":       "email",
+							"userinfo.token.claim": "true",
+						},
+						ConsentRequired: true,
+						ConsentText:     "${email}",
+						Name:            "email",
+						Protocol:        "openid-connect",
+						ProtocolMapper:  "oidc-usermodel-property-mapper",
+					},
+					{
+						Config: map[string]string{
+							"access.token.claim":   "true",
+							"claim.name":           "preferred_username",
+							"id.token.claim":       "true",
+							"jsonType.label":       "String",
+							"user.attribute":       "username",
+							"userinfo.token.claim": "true",
+						},
+						ConsentText:    "n.a.",
+						Name:           "username",
+						Protocol:       "openid-connect",
+						ProtocolMapper: "oidc-usermodel-property-mapper",
+					},
+				},
+				Access: map[string]bool{
+					"configure": true,
+					"manage":    true,
+					"view":      true,
+				},
+			},
+		},
+	}
+
+	if err := client.Create(ctx, keycloakClient); err != nil {
+		return fmt.Errorf("error occurred while creating keycloak client: %w", err)
+	}
+	return nil
+}
+
+func deleteKeycloakClient(ctx context.Context, client dynclient.Client) error {
+	err := wait.PollImmediate(time.Second*2, time.Minute*2, func() (done bool, err error) {
+		if err := client.Delete(ctx, &v1alpha1.KeycloakClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      keycloakClientName,
+				Namespace: keycloakClientNamespace,
+			},
+		}); err != nil {
+			if !k8errors.IsNotFound(err) {
+				return false, nil
+			}
+
+			if k8errors.IsNotFound(err) {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to delete testing idp keycloak client: %s", err)
+	}
+
+	return nil
+}
+
+// create keycloak realm
+func createKeycloakRealm(ctx context.Context, client dynclient.Client, installationName string) error {
+	keycloakRealm := &v1alpha1.KeycloakRealm{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestingIDPRealm,
+			Namespace: RHSSOProductNamespace,
+			Labels: map[string]string{
+				"sso": TestingIDPRealm,
+			},
+		},
+	}
+
+	keycloakRealmSpec := v1alpha1.KeycloakRealmSpec{
+		InstanceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"sso": "integreatly",
+			},
+		},
+		Realm: &v1alpha1.KeycloakAPIRealm{
+			ID:          TestingIDPRealm,
+			Realm:       TestingIDPRealm,
+			Enabled:     true,
+			DisplayName: "Testing IDP",
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, keycloakRealm, func() error {
+		keycloakRealm.Annotations = map[string]string{
+			"integreatly-namespace": RHMIOperatorNamespace,
+			"integreatly-name":      installationName,
+		}
+		keycloakRealm.Spec = keycloakRealmSpec
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating keycloak realm: %w", err)
+	}
+	return nil
+}
+
+// creates dedicated admin group
+func setupDedicatedAdminGroup(ctx context.Context, client dynclient.Client) error {
+	dedicatedAdminGroup := &userv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dedicated-admins",
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, dedicatedAdminGroup, func() error {
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating dedicated admins group : %w", err)
+	}
+
+	// create cluster role
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, dedicatedAdminClusterRole(), func() error {
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating dedicated admin cluster role: %w", err)
+	}
+
+	// create cluster role binding
+	if _, err := controllerutil.CreateOrUpdate(ctx, client, dedicatedAdminClusterRoleBindingCluster(), func() error {
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error occurred while creating or updating dedicated admin cluster role binding: %w", err)
+	}
+	return nil
+}
+
+func hasIDPCreated(ctx context.Context, client dynclient.Client, t TestingTB) bool {
+	clusterOauth := &configv1.OAuth{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, clusterOauth); err != nil {
+		t.Logf("error occurred while getting cluster oauth: %w", err)
+	}
+
+	idpExists := false
+	identityProviders := clusterOauth.Spec.IdentityProviders
+	if identityProviders != nil {
+		for _, providers := range identityProviders {
+			if providers.Name == TestingIDPRealm {
+				idpExists = true
+			}
+		}
+	}
+
+	return idpExists
+}
+
+// checks to see if a dedicated admin group exists
+func hasDedicatedAdminGroup(ctx context.Context, client dynclient.Client) bool {
+	dedicatedAdminGroup := &userv1.Group{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "dedicated-admins"}, dedicatedAdminGroup); err != nil {
+		return false
+	}
+	return true
+}
+
+func dedicatedAdminClusterRoleBindingCluster() *v12.ClusterRoleBinding {
+	return &v12.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "admin-dedicated-cluster",
+			Namespace: "dedicated-admin",
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind:       "Group",
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Name:       "dedicated-admins",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind:       "ClusterRole",
+			Name:       "dedicated-admin-cluster",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+	}
+}
+
+func dedicatedAdminClusterRole() *v12.ClusterRole {
+	return &v12.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dedicated-admin-cluster",
+		},
+		Rules: []v12.PolicyRule{
+			{
+				Verbs: []string{
+					"create",
+				},
+				APIGroups: []string{
+					"",
+					"project.openshift.io",
+				},
+				Resources: []string{
+					"projectrequests",
+				},
+			},
+			{
+				Verbs: []string{
+					"get",
+				},
+				APIGroups: []string{
+					"project.openshift.io",
+				},
+				Resources: []string{
+					"project",
+				},
+			},
+			{
+				Verbs: []string{
+					"get",
+					"list",
+					"update",
+					"patch",
+				},
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"namespaces",
+				},
+			},
+		},
+	}
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -1,0 +1,94 @@
+package common
+
+import "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+var (
+	ALL_TESTS = []TestCase{
+		// Add all tests that can be executed prior to a completed installation here
+		{"Verify RHMI CRD Exists", TestIntegreatlyCRDExists},
+		{"Verify RHMI Config CRD Exists", TestRHMIConfigCRDExists},
+	}
+
+	HAPPY_PATH_TESTS = []TestSuite{
+		//Add all happy path tests to be executed after RHMI installation is completed here
+		// {
+		// 	[]TestCase{
+		// 		{"F06 - Verify Replicas Scale correctly in Apicurito", TestReplicasInApicurito},
+		// 	},
+		// 	[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged},
+		// },
+		{
+			[]TestCase{
+				{"E09 - Verify customer dashboards exist", TestIntegreatlyCustomerDashboardsExist},
+				/*FLAKY on RHOAM*/ {"E10 - Verify Customer Grafana Route is accessible", TestCustomerGrafanaExternalRouteAccessible},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+		},
+		// {
+		// 	[]TestCase{
+		// 		// Keep test as first on the list, as it ensures that all products are reported as complete
+		// 		{"A01 - Verify that all stages in the integreatly-operator CR report completed", TestIntegreatlyStagesStatus},
+		// 		{"Test RHMI installation CR metric", TestRHMICRMetrics},
+		// 		{"A03 - Verify all namespaces have been created with the correct name", TestNamespaceCreated},
+		// 		{"A05 - Verify product operator version", TestProductOperatorVersions},
+		// 		{"A06 - Verify PVC", TestPVClaims},
+		// 		{"A07 - Verify product versions", TestProductVersions},
+		// 		{"A08 - Verify all products routes are created", TestIntegreatlyRoutesExist},
+		// 		{"A09 - Verify Subscription Install Plan Strategy", TestSubscriptionInstallPlanType},
+		// 		{"A10 - Verify CRO Postgres CRs Successful", TestCROPostgresSuccessfulState},
+		// 		{"A11 - Verify CRO Redis CRs Successful", TestCRORedisSuccessfulState},
+		// 		{"A12 - Verify CRO BlobStorage CRs Successful", TestCROBlobStorageSuccessfulState},
+		// 		{"A13 - Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},
+		// 		{"A14 - Verify Deployment Config resources have the expected replicas", TestDeploymentConfigExpectedReplicas},
+		// 		{"A15 - Verify Stateful Set resources have the expected replicas", TestStatefulSetsExpectedReplicas},
+		// 		{"A18 - Verify RHMI Config CRs Successful", TestRHMIConfigCRs},
+		// 		{"A22 - Verify RHMI Config Updates CRO Strategy Override Config Map", TestRHMIConfigCROStrategyOverride},
+		// 		/*FLAKY on RHMI and RHOAM in PROW*/ {"A26 - Verify Sendgrid Credentials Are Configured Properly", TestSendgridCredentialsAreValid},
+		// 		/*FLAKY on RHMI*/ {"C01 - Verify Alerts are not pending or firing apart from DeadMansSwitch", TestIntegreatlyAlertsPendingOrFiring},
+		// 		{"C04 - Verify Alerts exist", TestIntegreatlyAlertsExist},
+		// 		{"E01 - Verify Middleware Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
+		// 		{"E02 - Verify that all dashboards are installed and all the graphs are filled with data", TestDashboardsData},
+		// 		{"E03 - Verify middleware dashboards exist", TestIntegreatlyMiddelewareDashboardsExist},
+		// 		/*FLAKY on RHMI/RHOAM*/ {"E05 - Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
+		// 		{"F02 - Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
+		// 		{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},
+		// 		{"F08 - Verify Replicas Scale correctly in RHSSO", TestReplicasInRHSSO},
+		// 		{"F08 - Verify Replicas Scale correctly in User SSO", TestReplicasInUserSSO},
+		// 		{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
+		// 		/*FLAKY on RHMI*/ {"Verify Alerts are not firing during or after installation apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
+		// 		{"C03 - Verify that alerting mechanism works", TestIntegreatlyAlertsMechanism},
+		// 		{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
+		// 		{"A27 + A28 - Verify pod priority class is created and set", TestPriorityClass},
+		// 	},
+		// 	[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+		// },
+	}
+
+	IDP_BASED_TESTS = []TestSuite{
+		{
+			[]TestCase{
+				{"A16 - Custom first broker login flow", TestAuthDelayFirstBrokerLogin},
+				{"B03 - Verify RHMI Developer User Permissions are Correct", TestRHMIDeveloperUserPermissions},
+				{"B04 - Verify Dedicated Admin User Permissions are Correct", TestDedicatedAdminUserPermissions},
+				{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
+				{"H03 - Verify 3scale CRUDL permissions", Test3ScaleCrudlPermissions},
+				{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
+				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
+				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+		},
+		{
+			[]TestCase{
+				{"B05 - Verify Codeready CRUDL permissions", TestCodereadyCrudlPermisssions},
+				{"H05 - Verify Fuse CRUDL permissions", TestFuseCrudlPermissions},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged},
+		},
+	}
+
+	DESTRUCTIVE_TESTS = []TestCase{
+		// Add all destructive tests here that should not be executed as part of the happy path tests
+		{"J03 - Verify namespaces restored when deleted", TestNamespaceRestoration},
+	}
+)

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -1,14 +1,105 @@
 package common
 
 import (
+	"encoding/json"
+	"net/http"
 	"strings"
 
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	NamespacePrefix = GetNamespacePrefix()
+	NamespacePrefix                   = "redhat-rhoam-"
+	OpenShiftConsoleRoute             = "console"
+	OpenShiftConsoleNamespace         = "openshift-console"
+	RHMIOperatorNamespace             = NamespacePrefix + "operator"
+	MonitoringOperatorNamespace       = NamespacePrefix + "middleware-monitoring-operator"
+	MonitoringFederateNamespace       = NamespacePrefix + "middleware-monitoring-federate"
+	AMQOnlineOperatorNamespace        = NamespacePrefix + "amq-online"
+	ApicurioRegistryProductNamespace  = NamespacePrefix + "apicurio-registry"
+	ApicurioRegistryOperatorNamespace = ApicurioRegistryProductNamespace + "-operator"
+	ApicuritoProductNamespace         = NamespacePrefix + "apicurito"
+	ApicuritoOperatorNamespace        = ApicuritoProductNamespace + "-operator"
+	CloudResourceOperatorNamespace    = NamespacePrefix + "cloud-resources-operator"
+	CodeReadyProductNamespace         = NamespacePrefix + "codeready-workspaces"
+	CodeReadyOperatorNamespace        = CodeReadyProductNamespace + "-operator"
+	FuseProductNamespace              = NamespacePrefix + "fuse"
+	FuseOperatorNamespace             = FuseProductNamespace + "-operator"
+	RHSSOUserProductOperatorNamespace = NamespacePrefix + "user-sso"
+	RHSSOUserOperatorNamespace        = RHSSOUserProductOperatorNamespace + "-operator"
+	RHSSOProductNamespace             = NamespacePrefix + "rhsso"
+	RHSSOOperatorNamespace            = RHSSOProductNamespace + "-operator"
+	SolutionExplorerProductNamespace  = NamespacePrefix + "solution-explorer"
+	SolutionExplorerOperatorNamespace = SolutionExplorerProductNamespace + "-operator"
+	ThreeScaleProductNamespace        = NamespacePrefix + "3scale"
+	ThreeScaleOperatorNamespace       = ThreeScaleProductNamespace + "-operator"
+	UPSProductNamespace               = NamespacePrefix + "ups"
+	UPSOperatorNamespace              = UPSProductNamespace + "-operator"
+	MonitoringSpecNamespace           = NamespacePrefix + "monitoring"
+	Marin3rOperatorNamespace          = NamespacePrefix + "marin3r-operator"
+	Marin3rProductNamespace           = NamespacePrefix + "marin3r"
+	CustomerGrafanaNamespace          = NamespacePrefix + "customer-monitoring-operator"
 )
+
+type TestingContext struct {
+	Client          dynclient.Client
+	KubeConfig      *rest.Config
+	KubeClient      kubernetes.Interface
+	ExtensionClient *clientset.Clientset
+	HttpClient      *http.Client
+	SelfSignedCerts bool
+}
+
+type TestCase struct {
+	Description string
+	Test        func(t TestingTB, ctx *TestingContext)
+}
+
+type TestSuite struct {
+	TestCases   []TestCase
+	InstallType []rhmiv1alpha1.InstallationType
+}
+
+type Tests struct {
+	Type      string
+	TestCases []TestCase
+}
+
+type prometheusAPIResponse struct {
+	Status    string                 `json:"status"`
+	Data      json.RawMessage        `json:"data"`
+	ErrorType prometheusv1.ErrorType `json:"errorType"`
+	Error     string                 `json:"error"`
+	Warnings  []string               `json:"warnings,omitempty"`
+}
+
+type TestingTB interface {
+	Fail()
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Failed() bool
+	Parallel()
+	Skip(args ...interface{})
+	Skipf(format string, args ...interface{})
+	SkipNow()
+	Skipped() bool
+}
+
+type SubscriptionCheck struct {
+	Name      string
+	Namespace string
+}
 
 func GetNamespacePrefix() string {
 	ns, err := resources.GetWatchNamespace()
@@ -17,4 +108,50 @@ func GetNamespacePrefix() string {
 	}
 	return strings.Join(strings.Split(ns, "-")[0:2], "-") + "-"
 
+}
+
+func GetPrefixedNamespace(subNS string) string {
+	return NamespacePrefix + subNS
+}
+
+// ExpectedRoute contains the data of a route that is expected to be found
+type ExpectedRoute struct {
+	// Name is either the name of the route or the generated name (if the
+	// `IsGeneratedName` field is true)
+	Name string
+
+	isTLS bool
+
+	// ServiceName is the name of the service that the route points to (used
+	// when the name is generated as there can be multiple routes with the same
+	// generated name)
+	ServiceName string
+
+	IsGeneratedName bool
+}
+
+type PersistentVolumeClaim struct {
+	Namespace                  string
+	PersistentVolumeClaimNames []string
+}
+
+type StatefulSets struct {
+	Namespace string
+	Name      string
+}
+
+type Namespace struct {
+	Name                     string
+	Products                 []Product
+	PodDisruptionBudgetNames []string
+}
+
+type Product struct {
+	Name             string
+	ExpectedReplicas int32
+}
+
+type DeploymentConfigs struct {
+	Namespace string
+	Name      string
 }

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -1,0 +1,477 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+
+	enmasseadminv1beta1 "github.com/integr8ly/integreatly-operator/apis-products/enmasse/admin/v1beta1"
+	enmassev1beta1 "github.com/integr8ly/integreatly-operator/apis-products/enmasse/v1beta1"
+	enmassev1beta2 "github.com/integr8ly/integreatly-operator/apis-products/enmasse/v1beta2"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	projectv1 "github.com/openshift/api/project/v1"
+	v1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Common to all install types including managed api
+var commonNamespaces = []string{
+	"3scale",
+	"3scale-operator",
+	"middleware-monitoring",
+	"middleware-monitoring-operator",
+	"operator",
+	"rhsso",
+	"rhsso-operator",
+	"user-sso",
+	"user-sso-operator",
+}
+
+// Applicable to install types used in 2.X
+var rhmi2NamespacesPermissions = []string{
+	"amq-online",
+	"amq-online-operator",
+	"apicurito",
+	"apicurito-operator",
+	"cloud-resources-operator",
+	"codeready-workspaces",
+	"codeready-workspaces-operator",
+	"fuse",
+	"fuse-operator",
+	"solution-explorer",
+	"solution-explorer-operator",
+	"ups",
+	"ups-operator",
+}
+
+type ExpectedPermissions struct {
+	ExpectedCreateStatusCode int
+	ExpectedReadStatusCode   int
+	ExpectedUpdateStatusCode int
+	ExpectedDeleteStatusCode int
+	ExpectedListStatusCode   int
+	ListPath                 string
+	GetPath                  string
+	ObjectToCreate           interface{}
+}
+
+func TestDedicatedAdminUserPermissions(t TestingTB, ctx *TestingContext) {
+	customerAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	masterURL := rhmi.Spec.MasterURL
+
+	// get oauth route
+	oauthRoute := &v1.Route{}
+	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: resources.OpenshiftOAuthRouteName, Namespace: resources.OpenshiftAuthenticationNamespace}, oauthRoute); err != nil {
+		t.Fatal("error getting Openshift Oauth Route: ", err)
+	}
+
+	// get dedicated admin token
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), customerAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+		t.Fatalf("error occured trying to get token : %v", err)
+	}
+
+	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
+
+	// get projects for dedicated admin
+	dedicatedAdminFoundProjects, err := openshiftClient.ListProjects()
+	if err != nil {
+		t.Fatalf("error occured while getting user projects : %v", err)
+	}
+
+	// check if projects are as expected for rhmi developer
+	if result := verifyDedicatedAdminProjectPermissions(dedicatedAdminFoundProjects.Items); !result {
+		t.Fatal("test-failed - projects missing for dedicated-admins")
+	}
+
+	// Verify Dedicated admins permissions around secrets
+	verifyDedicatedAdminSecretPermissions(t, openshiftClient, rhmi.Spec.Type)
+
+	// Verify Dedicated admin permissions around RHMI Config
+	verifyDedicatedAdminRHMIConfigPermissions(t, openshiftClient)
+
+	verifyDedicatedAdmin3ScaleRoutePermissions(t, openshiftClient)
+
+	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+
+		// Verify dedicated admin permissions around StandardInfraConfig
+		verifyDedicatedAdminStandardInfraConfigPermissions(t, openshiftClient)
+
+		// Verify dedicated admin permissions around BrokeredInfraConfig
+		verifyDedicatedAdminBrokeredInfraConfigPermissions(t, openshiftClient)
+
+		// Verify dedicated admin permissions around AddressSpacePlan
+		verifyDedicatedAdminAddressSpacePlanPermissions(t, openshiftClient)
+
+		// Verify dedicated admin permissions around AddressPlan
+		verifyDedicatedAdminAddressPlanPermissions(t, openshiftClient)
+
+		// Verify dedicated admin permissions around AuthenticationService
+		verifyDedicatedAdminAuthenticationServicePermissions(t, openshiftClient)
+
+		// Verify dedicated admin Role / Role binding for AMQ Online resources
+		verifyDedicatedAdminAMQOnlineRolePermissions(t, ctx)
+	}
+}
+
+// Verify that a dedicated admin can edit routes in the 3scale namespace
+func verifyDedicatedAdmin3ScaleRoutePermissions(t TestingTB, client *resources.OpenshiftClient) {
+	ns := NamespacePrefix + "3scale"
+	route := "backend"
+
+	path := fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err := client.DoOpenshiftGetRequest(path)
+	if err != nil {
+		t.Errorf("Failed to get route : %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("Unable to get 3scale route as dedicated admin : %v", resp)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body) // Use response from GET
+	if err != nil {
+		t.Errorf("failed to read response body from get route request : %s", err)
+	}
+
+	path = fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err = client.DoOpenshiftPutRequest(path, bodyBytes)
+
+	if err != nil {
+		t.Errorf("Failed to update route : %s", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Failed to update route as dedicated admin : %v", resp)
+	}
+}
+
+// verifies that there is at least 1 project with a prefix `openshift` , `redhat` and `kube`
+func verifyDedicatedAdminProjectPermissions(projects []projectv1.Project) bool {
+	var hasOpenshiftPrefix, hasRedhatPrefix, hasKubePrefix bool
+	for _, ns := range projects {
+		if strings.HasPrefix(ns.Name, "openshift") {
+			hasOpenshiftPrefix = true
+		}
+		if strings.HasPrefix(ns.Name, "redhat") {
+			hasRedhatPrefix = true
+		}
+		if strings.HasPrefix(ns.Name, "kube") {
+			hasKubePrefix = true
+		}
+	}
+	return hasKubePrefix && hasRedhatPrefix && hasOpenshiftPrefix
+}
+
+func verifyDedicatedAdminSecretPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient, installType string) {
+	t.Log("Verifying Dedicated admin permissions for Secrets Resource")
+
+	productNamespaces := getProductNamespaces(installType)
+
+	// build array of rhmi namespaces
+	var rhmiNamespaces []string
+	for _, product := range productNamespaces {
+		rhmiNamespaces = append(rhmiNamespaces, fmt.Sprintf("%s%s", NamespacePrefix, product))
+	}
+
+	// check to ensure dedicated admin is forbidden from rhmi namespace secrets
+	for _, namespace := range rhmiNamespaces {
+		path := fmt.Sprintf(resources.OpenshiftPathGetSecret, namespace)
+		resp, err := openshiftClient.GetRequest(path)
+		if err != nil {
+			t.Errorf("error occurred while executing oc get request: %v", err)
+			continue
+		}
+		if resp.StatusCode != 403 {
+			t.Errorf("test-failed - status code found : %d expected status code : 403 RHMI dedicated admin should be forbidden from %s secrets", resp.StatusCode, namespace)
+		}
+	}
+
+	// check dedicated admin can get github oauth secret
+	resp, err := openshiftClient.GetRequest(fmt.Sprintf(resources.OpenshiftPathGetSecret, RHMIOperatorNamespace) + "/github-oauth-secret")
+	if err != nil {
+		t.Errorf("error occurred while executing oc get request: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("test-failed - status code found : %d expected status code : 200 - RHMI dedicated admin should have access to github oauth secret in %s", resp.StatusCode, RHMIOperatorNamespace)
+	}
+}
+
+func getProductNamespaces(installType string) []string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonNamespaces
+	} else {
+		return append(commonNamespaces, rhmi2NamespacesPermissions...)
+	}
+}
+
+// Verify Dedicated admin permissions for RHMIConfig Resource - CRUDL
+func verifyDedicatedAdminRHMIConfigPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for RHMIConfig Resource")
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 403,
+		ExpectedReadStatusCode:   403,
+		ExpectedUpdateStatusCode: 403,
+		ExpectedDeleteStatusCode: 403,
+		ExpectedListStatusCode:   403,
+		ListPath:                 fmt.Sprintf(resources.PathListRHMIConfig, RHMIOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetRHMIConfig, RHMIOperatorNamespace, "rhmi-config"),
+		ObjectToCreate: &integreatlyv1alpha1.RHMIConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-rhmi-config",
+				Namespace: RHMIOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1alpha1",
+				Kind:       "RHMIConfig",
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for StandardInfraConfig Resource - CRUDL
+func verifyDedicatedAdminStandardInfraConfigPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for StandardInfraConfig Resource")
+
+	resourceName := "test-standard-infra-config"
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListStandardInfraConfig, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetStandardInfraConfig, AMQOnlineOperatorNamespace, resourceName),
+		ObjectToCreate: enmassev1beta1.StandardInfraConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-standard-infra-config",
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "StandardInfraConfig",
+				APIVersion: "admin.enmasse.io/v1beta1",
+			},
+			Spec: enmassev1beta1.StandardInfraConfigSpec{
+				Broker: enmassev1beta1.InfraConfigBroker{
+					AddressFullPolicy: "FAIL",
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for BrokeredInfraConfig Resource - CRUDL
+func verifyDedicatedAdminBrokeredInfraConfigPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for BrokeredInfraConfig Resource")
+
+	resourceName := "test-brokered-infra-config"
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListBrokeredInfraConfig, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetBrokeredInfraConfig, AMQOnlineOperatorNamespace, resourceName),
+		ObjectToCreate: enmassev1beta1.BrokeredInfraConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "BrokeredInfraConfig",
+				APIVersion: "admin.enmasse.io/v1beta1",
+			},
+			Spec: enmassev1beta1.BrokeredInfraConfigSpec{
+				Broker: enmassev1beta1.InfraConfigBroker{
+					AddressFullPolicy: "FAIL",
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for AddressSpacePlan Resource - CRUDL
+func verifyDedicatedAdminAddressSpacePlanPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AddressSpacePlan Resource")
+
+	resourceName := "test-address-plan-space"
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListAddressSpacePlan, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetAddressSpacePlan, AMQOnlineOperatorNamespace, resourceName),
+		ObjectToCreate: enmassev1beta2.AddressSpacePlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AddressSpacePlan",
+				APIVersion: "admin.enmasse.io/v1beta2",
+			},
+			Spec: enmassev1beta2.AddressSpacePlanSpec{
+				AddressPlans:     []string{"standard-small-queue"},
+				AddressSpaceType: "standard",
+				InfraConfigRef:   "default-minimal",
+				ResourceLimits: enmassev1beta2.AddressSpacePlanResourceLimits{
+					Router:    1,
+					Broker:    1,
+					Aggregate: 1,
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for AddressPlan Resource - CRUDL
+func verifyDedicatedAdminAddressPlanPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AddressPlan Resource")
+
+	resourceName := "test-address-plan"
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListAddressPlan, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetAddressPlan, AMQOnlineOperatorNamespace, resourceName),
+		ObjectToCreate: enmassev1beta2.AddressPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AddressPlan",
+				APIVersion: "admin.enmasse.io/v1beta2",
+			},
+			Spec: enmassev1beta2.AddressPlanSpec{
+				AddressType: "queue",
+				Resources: enmassev1beta2.AddressPlanResources{
+					Router: 0.01,
+					Broker: 0.001,
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for AuthenticationService Resource - CRUDL
+func verifyDedicatedAdminAuthenticationServicePermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AuthenticationService Resource")
+
+	resourceName := "test-authentication-service"
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListAuthenticationService, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetAuthenticationService, AMQOnlineOperatorNamespace, resourceName),
+		ObjectToCreate: enmasseadminv1beta1.AuthenticationService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AuthenticationService",
+				APIVersion: "admin.enmasse.io/v1beta1",
+			},
+			Spec: enmasseadminv1beta1.AuthenticationServiceSpec{
+				Type: enmasseadminv1beta1.External,
+				External: &enmasseadminv1beta1.AuthenticationServiceSpecExternal{
+					Host: "test",
+					Port: 0,
+				},
+			},
+			Status: enmasseadminv1beta1.AuthenticationServiceStatus{
+				Host:  "test",
+				Phase: enmasseadminv1beta1.AuthenticationServiceActive,
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+func verifyDedicatedAdminAMQOnlineRolePermissions(t TestingTB, ctx *TestingContext) {
+	t.Log("Verifying Dedicated admin AMQ Online resource role / role binding")
+
+	roleBinding := &rbacv1.RoleBinding{}
+	if err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: "dedicated-admins-service-admin", Namespace: AMQOnlineOperatorNamespace}, roleBinding); err != nil {
+		t.Fatalf("error getting dedicated-admins-service-admin role binding in %s namespace: %s", AMQOnlineOperatorNamespace, err)
+	}
+
+	// Verify dedicated admin group is in role binding
+	found := false
+	for _, subject := range roleBinding.Subjects {
+		if subject.Name == "dedicated-admins" && subject.Kind == "Group" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("Did not find dedicated admin group in %s rolebinding in %s namespace", roleBinding.Name, roleBinding.Namespace)
+	}
+
+	// Verify permissions given by the role
+	role := &rbacv1.Role{}
+	if err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: roleBinding.RoleRef.Name, Namespace: AMQOnlineOperatorNamespace}, role); err != nil {
+		t.Fatalf("error %s role in %s namespace: %s", roleBinding.RoleRef.Name, AMQOnlineOperatorNamespace, err)
+	}
+
+	haveCorrectPermission := false
+	expectedRule := rbacv1.PolicyRule{
+		Verbs:     []string{"create", "get", "update", "delete", "list", "watch", "patch"},
+		APIGroups: []string{"admin.enmasse.io"},
+		Resources: []string{"addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"},
+	}
+
+	for _, rule := range role.Rules {
+		if reflect.DeepEqual(rule, expectedRule) {
+			haveCorrectPermission = true
+			break
+		}
+	}
+
+	if !haveCorrectPermission {
+		t.Fatalf("Incorrect permissions found for %s role in %s namespace. Excpected %s as a policy rule ", role.Name, role.Namespace, expectedRule)
+	}
+}

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -1,0 +1,209 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/google/go-querystring/query"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	projectv1 "github.com/openshift/api/project/v1"
+	v1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	expectedRhmiDeveloperProjectCount       = 1
+	expectedManagedApiDeveloperProjectCount = 0
+)
+
+// struct used to create query string for fuse logs endpoint
+type LogOptions struct {
+	Container string `url:"container"`
+	Follow    string `url:"follow"`
+	TailLines string `url:"tailLines"`
+}
+
+func TestRHMIDeveloperUserPermissions(t TestingTB, ctx *TestingContext) {
+	testUser := fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	masterURL := rhmi.Spec.MasterURL
+	t.Logf("retrieved console master URL %v", masterURL)
+
+	// get oauth route
+	oauthRoute := &v1.Route{}
+	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: resources.OpenshiftOAuthRouteName, Namespace: resources.OpenshiftAuthenticationNamespace}, oauthRoute); err != nil {
+		t.Fatal("error getting Openshift Oauth Route: ", err)
+	}
+	t.Log("retrieved openshift-Oauth route")
+
+	// get rhmi developer user tokens
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+		t.Fatalf("error occured trying to get token : %v", err)
+	}
+	t.Log("retrieved rhmi developer user tokens")
+	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
+
+	fuseNamespace := fmt.Sprintf("%sfuse", NamespacePrefix)
+	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		// test rhmi developer projects are as expected
+		t.Log("testing rhmi 2 developer projects")
+		if err := testRHMI2DeveloperProjects(masterURL, fuseNamespace, openshiftClient); err != nil {
+			t.Fatalf("test failed - %v", err)
+		}
+	} else {
+		// test managed api developer projects are as expected
+		t.Log("testing managed api developer projects")
+		if err := testManagedApiDeveloperProjects(masterURL, openshiftClient); err != nil {
+			t.Fatalf("test failed - %v", err)
+		}
+	}
+
+	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		// get fuse pods for rhmi developer
+		podlist, err := openshiftClient.ListPods(fuseNamespace)
+		if err != nil {
+			t.Fatalf("error occured while getting pods : %v", err)
+		}
+
+		// log through rhmi developer fuse podlist
+		for _, p := range podlist.Items {
+			if p.Status.Phase == "Running" {
+				logOpt := LogOptions{p.Spec.Containers[0].Name, "false", "10"}
+				lv, err := query.Values(logOpt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// verify an rhmi developer can access the pods logs
+				podPath := fmt.Sprintf(resources.OpenshiftPathListPods, p.Namespace)
+				resp, err := openshiftClient.GetRequest(fmt.Sprintf("%s/%s/log?%s", podPath, p.Name, lv.Encode()))
+				if err != nil {
+					t.Fatalf("error occurred making oc get request: %v", err)
+				}
+				if resp.StatusCode != 200 {
+					t.Fatalf("test-failed - status code %d RHMI developer unable to access fuse logs in pod %s : %v", resp.StatusCode, p.Name, err)
+				}
+			}
+		}
+	}
+
+	// Verify RHMI Developer permissions around RHMI Config
+	verifyRHMIDeveloperRHMIConfigPermissions(t, openshiftClient)
+
+	verifyRHMIDeveloper3ScaleRoutePermissions(t, openshiftClient)
+}
+
+// Verify that a dedicated admin can edit routes in the 3scale namespace
+func verifyRHMIDeveloper3ScaleRoutePermissions(t TestingTB, client *resources.OpenshiftClient) {
+	ns := NamespacePrefix + "3scale"
+	route := "backend"
+
+	path := fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err := client.DoOpenshiftGetRequest(path)
+	if err != nil {
+		t.Errorf("Failed to get route : %s", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("RHMI Developer was incorrectly able to get route : %v", resp)
+	}
+}
+
+func testRHMI2DeveloperProjects(masterURL, fuseNamespace string, openshiftClient *resources.OpenshiftClient) error {
+	var rhmiDevfoundProjects *projectv1.ProjectList
+	// five minute time out needed to ensure users have been reconciled by RHMI operator
+	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		rhmiDevfoundProjects, err = openshiftClient.ListProjects()
+		if err != nil {
+			return false, fmt.Errorf("error occured while getting user projects : %w", err)
+		}
+
+		// check if projects are as expected for rhmi developer
+		if len(rhmiDevfoundProjects.Items) != expectedRhmiDeveloperProjectCount {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		if rhmiDevfoundProjects != nil {
+			return fmt.Errorf("unexpected developer project count : %d expected project count : %d , error occurred - %w", len(rhmiDevfoundProjects.Items), expectedRhmiDeveloperProjectCount, err)
+		} else {
+			return fmt.Errorf("unexpected error occurred when retrieving projects list - %w", err)
+		}
+
+	}
+
+	foundNamespace := rhmiDevfoundProjects.Items[0].Name
+	if foundNamespace != fuseNamespace {
+		return fmt.Errorf("found rhmi developer project: %s expected rhmi developer project : %s", foundNamespace, fuseNamespace)
+	}
+
+	return nil
+}
+
+func testManagedApiDeveloperProjects(masterURL string, openshiftClient *resources.OpenshiftClient) error {
+	var rhmiDevfoundProjects *projectv1.ProjectList
+	// five minute time out needed to ensure users have been reconciled by RHMI operator
+	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		rhmiDevfoundProjects, err = openshiftClient.ListProjects()
+		if err != nil {
+			return false, fmt.Errorf("error occured while getting user projects : %w", err)
+		}
+
+		// check if projects are as expected for rhmi developer
+		if len(rhmiDevfoundProjects.Items) != expectedManagedApiDeveloperProjectCount {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		if rhmiDevfoundProjects != nil {
+			return fmt.Errorf("unexpected developer project count : %d expected project count : %d , error occurred - %w", len(rhmiDevfoundProjects.Items), expectedManagedApiDeveloperProjectCount, err)
+		} else {
+			return fmt.Errorf("unexpected error occurred when retrieving projects list - %w", err)
+		}
+
+	}
+
+	return nil
+}
+
+func verifyRHMIDeveloperRHMIConfigPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying RHMI Developer permissions for RHMIConfig Resource")
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 403,
+		ExpectedReadStatusCode:   403,
+		ExpectedUpdateStatusCode: 403,
+		ExpectedDeleteStatusCode: 403,
+		ExpectedListStatusCode:   403,
+		ListPath:                 fmt.Sprintf(resources.PathListRHMIConfig, RHMIOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetRHMIConfig, RHMIOperatorNamespace, "rhmi-config"),
+		ObjectToCreate: &integreatlyv1alpha1.RHMIConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-rhmi-config",
+				Namespace: RHMIOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1alpha1",
+				Kind:       "RHMIConfig",
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}

--- a/test/common/verify_metrics_scrapped.go
+++ b/test/common/verify_metrics_scrapped.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func mangedApiTargets() map[string][]string {
+	return map[string][]string{
+		// TODO: Should include other expected targets
+		Marin3rProductNamespace: {
+			"/prom-statsd-exporter/0",
+		},
+	}
+}
+
+func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
+	// get all active targets in prometheus
+	output, err := execToPod("curl localhost:9090/api/v1/targets?state=active",
+		"prometheus-application-monitoring-0",
+		GetPrefixedNamespace("middleware-monitoring-operator"),
+		"prometheus",
+		ctx)
+	if err != nil {
+		t.Fatalf("failed to exec to prometheus pod: %s", err)
+	}
+
+	// get all found active targets from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		t.Fatalf("failed to unmarshal json: %s", err)
+	}
+
+	var targetResult prometheusv1.TargetsResult
+	err = json.Unmarshal(promApiCallOutput.Data, &targetResult)
+	if err != nil {
+		t.Fatalf("failed to unmarshal json: %s", err)
+	}
+
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// for every namespace
+	for ns, targets := range getTargets(rhmi.Spec.Type) {
+		// for every listed target in namespace
+		for _, targetName := range targets {
+			// check that metrics is being correctly scrapped by target
+			correctlyScrapping := false
+			for _, target := range targetResult.Active {
+				if target.DiscoveredLabels["job"] == fmt.Sprintf("%s%s", ns, targetName) && target.Health == prometheusv1.HealthGood && target.ScrapeURL != "" {
+					correctlyScrapping = true
+					break
+				}
+			}
+
+			if !correctlyScrapping {
+				t.Errorf("Not correctly scrapping Prometheus target: %s%s", ns, targetName)
+			}
+		}
+	}
+}
+
+func getTargets(installType string) map[string][]string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return mangedApiTargets()
+	} else {
+		// TODO - return list for managed install type
+		return map[string][]string{}
+	}
+}

--- a/test/e2e/integretly_test.go
+++ b/test/e2e/integretly_test.go
@@ -1,0 +1,62 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("integreatly", func() {
+
+	var (
+		restConfig = cfg
+		t          = GinkgoT()
+	)
+
+	BeforeEach(func() {
+		restConfig = cfg
+		t = GinkgoT()
+	})
+
+	RunTests := func() {
+
+		tests := []common.Tests{
+			{
+				Type:      "ALL TESTS",
+				TestCases: common.ALL_TESTS,
+			},
+			{
+				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
+				TestCases: common.GetHappyPathTestCases(installType),
+			},
+		}
+
+		if os.Getenv("DESTRUCTIVE") == "true" {
+			tests = append(tests, common.Tests{
+				Type:      "Destructive Tests",
+				TestCases: common.DESTRUCTIVE_TESTS,
+			})
+		}
+
+		for _, test := range tests {
+			Context(test.Type, func() {
+				for _, testCase := range test.TestCases {
+					currentTest := testCase
+					It(currentTest.Description, func() {
+						testingContext, err := common.NewTestingContext(restConfig)
+						if err != nil {
+							t.Fatal("failed to create testing context", err)
+						}
+						currentTest.Test(t, testingContext)
+					})
+				}
+			})
+		}
+
+	}
+
+	RunTests()
+
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var installType string
+var err error
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	// start test env
+	By("bootstrapping test environment")
+
+	useCluster := true
+	testEnv = &envtest.Environment{
+		UseExistingCluster:       &useCluster,
+		AttachControlPlaneOutput: true,
+	}
+	cfg, err = testEnv.Start()
+	if err != nil {
+		t.Fatalf("could not get start test environment %s", err)
+	}
+	//TODO: Trigger operator install
+
+	//TODO: validate operator has completed install
+
+	// get install type
+	installType, err = common.GetInstallType(cfg)
+	if err != nil {
+		t.Fatalf("could not get install type %s", err)
+	}
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"E2E Test Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	err = rhmiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	close(done)
+}, 120)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/functional/aws_elasticache_resources_exist.go
+++ b/test/functional/aws_elasticache_resources_exist.go
@@ -1,0 +1,77 @@
+package functional
+
+import (
+	goctx "context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingContext) {
+	goContext := goctx.TODO()
+
+	rhmi, err := common.GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// build an array of redis resources to check and test error array
+	elasticacheResourceIDs, testErrors := GetElasticacheResourceIDs(goContext, ctx.Client, rhmi)
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test cro redis exists failed with the following errors : %s", testErrors)
+	}
+
+	// create AWS session
+	sess, err := CreateAWSSession(goContext, ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to create aws session: %v", err)
+	}
+
+	// create new elasticache api with retrieved session
+	elasticacheapi := elasticache.New(sess)
+
+	// iterate through returned resource ID's
+	for _, resourceID := range elasticacheResourceIDs {
+		//get elasticache resources through new elasticacheapi
+		foundElasticacheReplicationGroups, err := elasticacheapi.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
+			ReplicationGroupId: aws.String(resourceID),
+		})
+		if err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("failed to get %s elasticache replicationgroups with error : %v", resourceID, err))
+			continue
+		}
+		if len(foundElasticacheReplicationGroups.ReplicationGroups[0].NodeGroups) > 1 {
+			testErrors = append(testErrors, fmt.Sprintf("insufficient number of nodes in elasticache group"))
+			continue
+		}
+		replicationGroup := foundElasticacheReplicationGroups.ReplicationGroups[0]
+		nodeGroup := replicationGroup.NodeGroups[0]
+
+		// perform checks to verify state is as expected
+		if !verifyMultiAZ(nodeGroup.NodeGroupMembers) {
+			testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s multiAZ failure %v", resourceID, err))
+		}
+		if !aws.BoolValue(replicationGroup.AtRestEncryptionEnabled) {
+			testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have encryption enabled", resourceID))
+		}
+		if replicationGroup.SnapshotWindow == nil {
+			testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have automatic snapshotting enabled", resourceID))
+		}
+	}
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test elasticache instances exists failed with the following errors : %s", testErrors)
+	}
+
+}
+
+// helper method for verifying nodes are in different availability zones
+func verifyMultiAZ(member []*elasticache.NodeGroupMember) bool {
+	if member[0].PreferredAvailabilityZone == member[1].PreferredAvailabilityZone {
+		return false
+	}
+	return true
+}

--- a/test/functional/aws_legacy_cluster_vpc.go
+++ b/test/functional/aws_legacy_cluster_vpc.go
@@ -1,0 +1,319 @@
+package functional
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/test/common"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var internalSubnetTag = "kubernetes.io/role/internal-elb"
+
+func TestLegacyClusterVPC(t common.TestingTB, testingCtx *common.TestingContext) {
+	ctx := context.TODO()
+	testErrors := &networkConfigTestError{}
+
+	// get the aws strategy map to get the vpc cidr block
+	// from the _network key
+	strategyMap := &v1.ConfigMap{}
+	err := testingCtx.Client.Get(ctx, types.NamespacedName{
+		Namespace: common.RHMIOperatorNamespace,
+		Name:      strategyMapName,
+	}, strategyMap)
+
+	if err != nil {
+		t.Fatal("could not get aws strategy map", err)
+	}
+
+	// get the create strategy for _network in the aws strategy configmap
+	// if this doesn't exist, skip the test completely since we're dealing
+	// with legacy cro networking
+	networkStrategy := strategyMap.Data[resourceType]
+	if networkStrategy != "" {
+		t.Skip("_network key exists in aws strategy configmap, skipping legacy cluster vpc network test")
+	}
+	t.Log("Doing Legacy VPC Test")
+
+	// get the cluster id used for tagging aws resources
+	clusterTag, err := getClusterID(ctx, testingCtx.Client)
+	if err != nil {
+		t.Fatal("could not get cluster id", err)
+	}
+
+	// create a new session
+	session, err := CreateAWSSession(ctx, testingCtx.Client)
+	if err != nil {
+		t.Fatal("could not create aws session", err)
+	}
+
+	ec2Svc := ec2.New(session)
+
+	// Get the availability zones for the region the cluster is in
+	azs, err := getAvailabilityZones(ec2Svc)
+
+	if err != nil {
+		t.Fatal("could not get aws availability zones", err)
+	}
+
+	// find and verify the cluster VPC
+	vpc, err := verifyLegacyVPC(ec2Svc, clusterTag)
+	testErrors.vpcError = err.(*networkConfigTestError).vpcError
+
+	if vpc == nil {
+		t.Fatal(testErrors.Error())
+	}
+
+	clusterVpcId := *vpc.VpcId
+
+	vpcSubnets, err := getLegacySubnets(ec2Svc, clusterTag, clusterVpcId)
+	testErrors.subnetsError = err.(*networkConfigTestError).subnetsError
+
+	// we have to manually construct the subnet group names for rds and elasticache,
+	// since tag filtering isnt currently available
+	subnetGroupName := resources.ShortenString(fmt.Sprintf("%s-%s", clusterTag, "subnet-group"), 40)
+
+	rdsSvc := rds.New(session)
+	err = verifyLegacyRDSSubnetGroups(rdsSvc, subnetGroupName, clusterVpcId, vpcSubnets, azs)
+	testErrors.rdsSubnetGroupsError = err.(*networkConfigTestError).rdsSubnetGroupsError
+
+	cacheSvc := elasticache.New(session)
+	err = verifyLegacyCacheSubnetGroups(cacheSvc, subnetGroupName, clusterVpcId, vpcSubnets, azs)
+	testErrors.cacheSubnetGroupsError = err.(*networkConfigTestError).cacheSubnetGroupsError
+
+	// if any error was found, fail the test
+	if testErrors.hasError() {
+		t.Fatal(testErrors.Error())
+	}
+}
+
+func getAvailabilityZones(ec2Svc *ec2.EC2) ([]*string, error) {
+	azs := make([]*string, 0)
+
+	describeOutput, err := ec2Svc.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{})
+
+	if err != nil {
+		return azs, err
+	}
+
+	for _, zone := range describeOutput.AvailabilityZones {
+		azs = append(azs, zone.ZoneName)
+	}
+
+	return azs, nil
+}
+
+func verifyLegacyVPC(session *ec2.EC2, clusterTag string) (*ec2.Vpc, error) {
+	// filter vpcs by integreatly cluster id tag
+
+	newErr := &networkConfigTestError{
+		vpcError: []error{},
+	}
+
+	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", clusterTag)),
+				Values: []*string{aws.String("owned")},
+			},
+		},
+	})
+	if err != nil {
+		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("could not find vpc: %v", err))
+		return nil, newErr
+	}
+
+	// only one vpc is expected
+	vpcs := describeVpcs.Vpcs
+	if len(vpcs) != 1 {
+		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("expected 1 vpc but found %d", len(vpcs)))
+		return nil, newErr
+	}
+
+	return vpcs[0], newErr
+}
+
+// verify that the vpc subnets are created
+func getLegacySubnets(session *ec2.EC2, clusterTag, clusterVPCId string) ([]*ec2.Subnet, error) {
+	newErr := &networkConfigTestError{
+		subnetsError: []error{},
+	}
+
+	// filter subnets by integreatly cluster id tag
+	describeSubnets, err := session.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{aws.String(clusterVPCId)},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not describe subnets: %v", err)
+		newErr.subnetsError = append(newErr.subnetsError, errMsg)
+		return nil, newErr
+	}
+
+	return describeSubnets.Subnets, newErr
+}
+
+func verifyLegacyRDSSubnetGroups(rdsSvc *rds.RDS, subnetGroupName, clusterVPCId string, vpcSubnets []*ec2.Subnet, azs []*string) error {
+	newErr := &networkConfigTestError{
+		rdsSubnetGroupsError: []error{},
+	}
+
+	// get rds subnet groups by subnet group name
+	describeGroups, err := rdsSvc.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: aws.String(subnetGroupName),
+	})
+
+	if err != nil {
+		errMsg := fmt.Errorf("error describing rds subnet groups: %v", err)
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	// expect 1 subnet group
+	subnetGroups := describeGroups.DBSubnetGroups
+	if len(subnetGroups) != 1 {
+		errMsg := fmt.Errorf("unexpected number of rds subnet groups: %d", len(subnetGroups))
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	subnetGroup := subnetGroups[0]
+
+	// ensure the subnet group belongs to the cluster VPC
+	if *subnetGroup.VpcId != clusterVPCId {
+		errMsg := fmt.Errorf("rds subnet group %s does not belong to cluster VPC. got = %s, wanted = %s", *subnetGroup.DBSubnetGroupName, *subnetGroup.VpcId, clusterVPCId)
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+	}
+
+	// ensure each subnet is found in the list of subnets found in the cluster vpc
+	subnetGroupSubnets := make([]*ec2.Subnet, 0)
+	for _, cacheSubnet := range subnetGroup.Subnets {
+		ec2Subnet := findSubnetInList(*cacheSubnet.SubnetIdentifier, vpcSubnets)
+		if ec2Subnet == nil {
+			errMsg := fmt.Errorf("rds subnet group %+v has a subnet that doesn't belong to the cluster VPC %s", subnetGroup, clusterVPCId)
+			newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		}
+		subnetGroupSubnets = append(subnetGroupSubnets, ec2Subnet)
+	}
+
+	// verify that the subnets have the right tag that indicates it's private
+	for _, subnet := range subnetGroupSubnets {
+		if !subnetContainsTagKey(subnet, internalSubnetTag) {
+			errMsg := fmt.Errorf("rds subnet %s doesn't have the tag %s", *subnet.SubnetId, internalSubnetTag)
+			newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		}
+	}
+
+	// the list of availability zones that have been covered by the subnets
+	// within the DBSubnetGroup
+	coveredAZs := make([]*string, 0)
+	for _, subnet := range subnetGroup.Subnets {
+		if !contains(coveredAZs, subnet.SubnetAvailabilityZone.Name) {
+			coveredAZs = append(coveredAZs, subnet.SubnetAvailabilityZone.Name)
+		}
+	}
+
+	// check the lengths match, i.e. the subnets cover every AZ in the region
+	if len(coveredAZs) != len(azs) {
+		errMsg := fmt.Errorf("rds subnet group does not have a subnet group for each availability zone. Availability Zones: %+v Subnet Groups: %+v", subnetGroup.Subnets, azs)
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+	}
+
+	return newErr
+}
+
+func verifyLegacyCacheSubnetGroups(cacheSvc *elasticache.ElastiCache, subnetGroupName, clusterVPCId string, vpcSubnets []*ec2.Subnet, azs []*string) error {
+	newErr := &networkConfigTestError{
+		cacheSubnetGroupsError: []error{},
+	}
+
+	// get elasticache subnet groups by subnet group name
+	describeCacheGroups, err := cacheSvc.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{
+		CacheSubnetGroupName: aws.String(subnetGroupName),
+	})
+
+	if err != nil {
+		errMsg := fmt.Errorf("error describing elasticache subnet groups: %v", err)
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	// expect 1 subnet group
+	cacheSubnetGroups := describeCacheGroups.CacheSubnetGroups
+	if len(cacheSubnetGroups) != 1 {
+		errMsg := fmt.Errorf("unexpected number of elasticache subnet groups: %d", len(cacheSubnetGroups))
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+	}
+
+	subnetGroup := cacheSubnetGroups[0]
+
+	// ensure the subnet group belongs to the cluster vpc
+	if *subnetGroup.VpcId != clusterVPCId {
+		errMsg := fmt.Errorf("elasticache subnet group %s does not belong to cluster VPC. got = %s, wanted = %s", *subnetGroup.CacheSubnetGroupName, *subnetGroup.VpcId, clusterVPCId)
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+	}
+
+	// ensure each subnet is found in the list of subnets found in the cluster vpc
+	subnetGroupSubnets := make([]*ec2.Subnet, 0)
+	for _, cacheSubnet := range subnetGroup.Subnets {
+		ec2Subnet := findSubnetInList(*cacheSubnet.SubnetIdentifier, vpcSubnets)
+		if ec2Subnet == nil {
+			errMsg := fmt.Errorf("elasticache subnet group %+v has a subnet that doesn't belong to the cluster VPC %s", subnetGroup, clusterVPCId)
+			newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+		}
+		subnetGroupSubnets = append(subnetGroupSubnets, ec2Subnet)
+	}
+
+	// verify that the subnets have the right tag that indicates it's private
+	for _, subnet := range subnetGroupSubnets {
+		if !subnetContainsTagKey(subnet, internalSubnetTag) {
+			errMsg := fmt.Errorf("elasticache subnet %s doesn't have the tag %s", *subnet.SubnetId, internalSubnetTag)
+			newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+		}
+	}
+
+	// the list of availability zones that have been covered by the subnets
+	// within the DBSubnetGroup
+	coveredAZs := make([]*string, 0)
+	for _, subnet := range subnetGroup.Subnets {
+		if !contains(coveredAZs, subnet.SubnetAvailabilityZone.Name) {
+			coveredAZs = append(coveredAZs, subnet.SubnetAvailabilityZone.Name)
+		}
+	}
+
+	// check the lengths match, i.e. the subnets cover every AZ in the region
+	if len(coveredAZs) != len(azs) {
+		errMsg := fmt.Errorf("elasticache subnet group does not have a subnet group for each availability zone. Availability Zones: %+v Subnet Groups: %+v", subnetGroup.Subnets, azs)
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+	}
+
+	return newErr
+}
+
+func findSubnetInList(subnetIdentifier string, vpcSubnets []*ec2.Subnet) *ec2.Subnet {
+	for _, vpcSubnet := range vpcSubnets {
+		if subnetIdentifier == *vpcSubnet.SubnetId {
+			return vpcSubnet
+		}
+	}
+	return nil
+}
+
+func subnetContainsTagKey(subnet *ec2.Subnet, tagKey string) bool {
+	for _, tag := range subnet.Tags {
+		if *tag.Key == tagKey {
+			return true
+		}
+	}
+	return false
+}

--- a/test/functional/aws_rds_resources_exist.go
+++ b/test/functional/aws_rds_resources_exist.go
@@ -1,0 +1,57 @@
+package functional
+
+import (
+	goctx "context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+func AWSRDSResourcesExistTest(t common.TestingTB, ctx *common.TestingContext) {
+	goContext := goctx.TODO()
+
+	rhmi, err := common.GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// build an array of postgres resources to check and an array of test errors
+	rdsResourceIDs, testErrors := GetRDSResourceIDs(goContext, ctx.Client, rhmi)
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test cro postgres exists failed with the following errors : %s", testErrors)
+	}
+	sess, err := CreateAWSSession(goContext, ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to create aws session: %v", err)
+	}
+
+	// check ever expected resource
+	rdsapi := rds.New(sess)
+	for _, resourceIdentifier := range rdsResourceIDs {
+		// get the rds instance
+		foundRDSInstances, err := rdsapi.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: aws.String(resourceIdentifier),
+		})
+		if err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("failed to get rds instance :%s with error : %v", resourceIdentifier, err))
+			continue
+		}
+		// verify the rds instance is as expected
+		if !verifyRDSInstanceConfig(*foundRDSInstances.DBInstances[0]) {
+			testErrors = append(testErrors, fmt.Sprintf("failed as rds %s resource is not as expected", resourceIdentifier))
+		}
+	}
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test cro postgres exists failed with the following errors : %s", testErrors)
+	}
+
+}
+
+// return expected resource variables
+func verifyRDSInstanceConfig(instance rds.DBInstance) bool {
+	return *instance.MultiAZ && *instance.DeletionProtection && *instance.StorageEncrypted && *instance.AutoMinorVersionUpgrade == false && *instance.EngineVersion == "10.13"
+}

--- a/test/functional/aws_s3_resources_exist.go
+++ b/test/functional/aws_s3_resources_exist.go
@@ -1,0 +1,153 @@
+package functional
+
+import (
+	goctx "context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+const (
+	expectedBucketEncryption = "AES256"
+	resourceNameTag          = "integreatly.org/resource-name"
+)
+
+func getExpectedBackupBucketResourceName(installationName string) string {
+	return fmt.Sprintf("backups-blobstorage-%s", installationName)
+}
+
+func getExpectedThreeScaleBucketResourceName(installationName string) string {
+	return fmt.Sprintf("threescale-blobstorage-%s", installationName)
+}
+
+func TestAWSs3BlobStorageResourcesExist(t common.TestingTB, ctx *common.TestingContext) {
+	goContext := goctx.TODO()
+
+	rhmi, err := common.GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	s3ResourceIDs, testErrors := GetS3BlobStorageResourceIDs(goContext, ctx.Client, rhmi)
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test cro blob storage exists failed with the following errors : %s", testErrors)
+	}
+
+	// Expect 2 blobstorage for RHMI
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) && len(s3ResourceIDs) != 2 {
+		t.Fatalf("There should be exactly 2 blob resources for %s install type: actual: %d", rhmi.Spec.Type, len(s3ResourceIDs))
+	}
+
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && len(s3ResourceIDs) != 1 {
+		t.Fatalf("There should be exactly 1 blob resources for %s install type: actual: %d", rhmi.Spec.Type, len(s3ResourceIDs))
+	}
+
+	sess, err := CreateAWSSession(goContext, ctx.Client)
+	if err != nil {
+		t.Fatalf("failed to create aws session: %v", err)
+	}
+
+	s3api := s3.New(sess)
+
+	backupsFound := new(bool)
+	threeScaleFound := new(bool)
+
+	for _, resourceIdentifier := range s3ResourceIDs {
+
+		err := verifyEncryption(s3api, resourceIdentifier)
+		if err != nil {
+			testErrors = append(testErrors, err.Error())
+		}
+
+		err = verifyPublicAccessBlock(s3api, resourceIdentifier)
+		if err != nil {
+			testErrors = append(testErrors, err.Error())
+		}
+
+		err = verifyResourceNames(s3api, resourceIdentifier, backupsFound, threeScaleFound, rhmi.Name)
+		if err != nil {
+			testErrors = append(testErrors, err.Error())
+		}
+	}
+
+	// Expect both backup and three scale bucket for managed install
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) && (*backupsFound == false || *threeScaleFound == false) {
+		testErrors = append(testErrors, fmt.Sprintf("Failed to find appropriate resource names for buckets for managed install"))
+	}
+
+	// Expect just three scale bucket for managed api install
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && *threeScaleFound == false {
+		testErrors = append(testErrors, fmt.Sprintf("Failed to find appropriate resource names for buckets for managed api install"))
+	}
+
+	if len(testErrors) != 0 {
+		t.Fatalf("test s3 blob storage failed with the following errors : %s", testErrors)
+	}
+
+}
+
+func verifyEncryption(s3api *s3.S3, identifier string) error {
+
+	enc, err := s3api.GetBucketEncryption(&s3.GetBucketEncryptionInput{Bucket: aws.String(identifier)})
+	if err != nil {
+		return fmt.Errorf("Error getting bucket encryption, bucket :%s, %w", identifier, err)
+	}
+	if enc.ServerSideEncryptionConfiguration == nil {
+		return fmt.Errorf("Server Side Encryption does not exist for bucket :%s", identifier)
+	}
+	rules := enc.ServerSideEncryptionConfiguration.Rules
+	for _, rule := range rules {
+		if *rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm == expectedBucketEncryption {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Server Side Encryption does not exist for bucket :%s, %w", identifier, err)
+}
+
+func verifyPublicAccessBlock(s3api *s3.S3, identifier string) error {
+
+	pab, err := s3api.GetPublicAccessBlock(&s3.GetPublicAccessBlockInput{Bucket: aws.String(identifier)})
+	if err != nil {
+		return fmt.Errorf("Error getting bucket public access block, bucket :%s, %w", identifier, err)
+	}
+	if pab.PublicAccessBlockConfiguration == nil {
+		return fmt.Errorf("Public Access is not defined for bucket :%s", identifier)
+	}
+	if *pab.PublicAccessBlockConfiguration.BlockPublicPolicy == true {
+		return nil
+	} else {
+		return fmt.Errorf("Public Access is not blocked for Bucket :%s", identifier)
+	}
+}
+
+func verifyResourceNames(s3api *s3.S3, identifier string, backupsFound *bool, threeScaleFound *bool, installationName string) error {
+
+	tags, err := s3api.GetBucketTagging(&s3.GetBucketTaggingInput{Bucket: aws.String(identifier)})
+	if err != nil {
+		return fmt.Errorf("Error getting bucket tags, bucket :%s, %w", identifier, err)
+	}
+	if tags.TagSet == nil {
+		return fmt.Errorf("Tags are not defined for bucket :%s", identifier)
+	}
+	for i := range tags.TagSet {
+		tag := tags.TagSet[i]
+		if *tag.Key == resourceNameTag {
+			if *tag.Value == getExpectedBackupBucketResourceName(installationName) {
+				*backupsFound = true
+				return nil
+			}
+			if *tag.Value == getExpectedThreeScaleBucketResourceName(installationName) {
+				*threeScaleFound = true
+				return nil
+			}
+			return fmt.Errorf("Unexpected resource name for bucket :%s, %s", identifier, *tag.Value)
+		}
+	}
+	return fmt.Errorf("No resource name tag for bucket :%s", identifier)
+}

--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -1,0 +1,303 @@
+package functional
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	"github.com/integr8ly/integreatly-operator/test/common"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	awsCredsNamespace  = "kube-system"
+	awsCredsSecretName = "aws-creds"
+)
+
+func getExpectedPostgres(installType string, installationName string) []string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		// expected postgres resources provisioned per product
+		return []string{
+			fmt.Sprintf("%s%s", constants.ThreeScalePostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.RHSSOUserProstgresPrefix, installationName),
+		}
+	} else {
+		// expected postgres resources provisioned per product
+		return []string{
+			fmt.Sprintf("%s%s", constants.CodeReadyPostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.ThreeScalePostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.RHSSOUserProstgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.UPSPostgresPrefix, installationName),
+			fmt.Sprintf("%s%s", constants.FusePostgresPrefix, installationName),
+		}
+	}
+}
+
+func getExpectedRedis(installType string, installationName string) []string {
+	// expected redis resources provisioned per product
+	commonRedis := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScaleBackendRedisPrefix, installationName),
+		fmt.Sprintf("%s%s", constants.ThreeScaleSystemRedisPrefix, installationName),
+	}
+
+	managedApiRedis := []string{
+		fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, installationName),
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return append(commonRedis, managedApiRedis...)
+	} else {
+		return commonRedis
+	}
+}
+
+func getExpectedBlobStorage(installType string, installationName string) []string {
+	// common blob storage
+	commonBlobStorage := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScaleBlobStoragePrefix, installationName),
+	}
+
+	// rhmi blob storage
+	rhmiBlobStorage := []string{
+		fmt.Sprintf("%s%s", constants.ThreeScaleBlobStoragePrefix, installationName),
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return commonBlobStorage
+	} else {
+		return append(commonBlobStorage, rhmiBlobStorage...)
+	}
+}
+
+/*
+	Each resource provisioned contains an annotation with the resource ID
+	This function iterates over a list of expected resource CR's
+	Returns a list of resource ID's, these ID's can be used when testing AWS resources
+*/
+func GetElasticacheResourceIDs(ctx context.Context, client client.Client, rhmi *integreatlyv1alpha1.RHMI) ([]string, []string) {
+	var foundErrors []string
+	var foundResourceIDs []string
+
+	expectedRedis := getExpectedRedis(rhmi.Spec.Type, rhmi.Name)
+
+	for _, r := range expectedRedis {
+		// get elasticache cr
+		redis := &crov1.Redis{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: common.RHMIOperatorNamespace, Name: r}, redis); err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfailed to find %s redis cr : %v", r, err))
+		}
+		// ensure phase is completed
+		if redis.Status.Phase != croTypes.PhaseComplete {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfound %s redis not ready with phase: %s, message: %s", r, redis.Status.Phase, redis.Status.Message))
+		}
+		// return resource id
+		resourceID, err := getCROAnnotation(redis)
+		if err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\n%s redis cr does not contain a resource id annotation: %v", r, err))
+		}
+		// populate the array
+		foundResourceIDs = append(foundResourceIDs, resourceID)
+	}
+	return foundResourceIDs, foundErrors
+}
+
+/*
+	Each resource provisioned contains an annotation with the resource ID
+	This function iterates over a list of expected resource CR's
+	Returns a list of resource ID's, these ID's can be used when testing AWS resources
+*/
+func GetRDSResourceIDs(ctx context.Context, client client.Client, rhmi *integreatlyv1alpha1.RHMI) ([]string, []string) {
+	var foundErrors []string
+	var foundResourceIDs []string
+
+	expectedPostgres := getExpectedPostgres(rhmi.Spec.Type, rhmi.Name)
+
+	for _, r := range expectedPostgres {
+		// get rds cr
+		postgres := &crov1.Postgres{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: common.RHMIOperatorNamespace, Name: r}, postgres); err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfailed to find %s postgres cr : %v", r, err))
+		}
+		// ensure phase is completed
+		if postgres.Status.Phase != croTypes.PhaseComplete {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfound %s postgres not ready with phase: %s, message: %s", r, postgres.Status.Phase, postgres.Status.Message))
+		}
+		// return resource id
+		resourceID, err := getCROAnnotation(postgres)
+		if err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\n%s postgres cr does not contain a resource id annotation: %v", r, err))
+		}
+		// populate the array
+		foundResourceIDs = append(foundResourceIDs, resourceID)
+	}
+	return foundResourceIDs, foundErrors
+}
+
+func GetS3BlobStorageResourceIDs(ctx context.Context, client client.Client, rhmi *integreatlyv1alpha1.RHMI) ([]string, []string) {
+	var foundErrors []string
+	var foundResourceIDs []string
+
+	expectedBlobStorage := getExpectedBlobStorage(rhmi.Spec.Type, rhmi.Name)
+
+	for _, r := range expectedBlobStorage {
+		// get rds cr
+		blobStorage := &crov1.BlobStorage{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: common.RHMIOperatorNamespace, Name: r}, blobStorage); err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfailed to find %s blobStorage cr : %v", r, err))
+		}
+		// ensure phase is completed
+		if blobStorage.Status.Phase != croTypes.PhaseComplete {
+			foundErrors = append(foundErrors, fmt.Sprintf("\nfound %s blobStorage not ready with phase: %s, message: %s", r, blobStorage.Status.Phase, blobStorage.Status.Message))
+		}
+		// return resource id
+		resourceID, err := getCROAnnotation(blobStorage)
+		if err != nil {
+			foundErrors = append(foundErrors, fmt.Sprintf("\n%s blobStorage cr does not contain a resource id annotation: %v", r, err))
+		}
+		// populate the array
+		foundResourceIDs = append(foundResourceIDs, resourceID)
+	}
+
+	return foundResourceIDs, foundErrors
+}
+
+// creates a session to be used in getting an api instance for aws
+func CreateAWSSession(ctx context.Context, client client.Client) (*session.Session, error) {
+	//retrieve aws credentials for creating an aws session
+	awsSecretAccessKey, awsAccessKeyID, err := getAWSCredentials(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS credentials : %w", err)
+	}
+
+	//retrieve aws region for creating an aws session
+	region, err := getAWSRegion(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS cluster region : %w", err)
+	}
+
+	//create new session for aws api's
+	sess, err := createAWSSession(awsSecretAccessKey, awsAccessKeyID, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session : %w", err)
+	}
+	return sess, nil
+}
+
+// createAWSSession returns a new session from aws
+func createAWSSession(awsAccessKeyID, awsSecretAccessKey, region string) (*session.Session, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, ""),
+		Region:      aws.String(region),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new session with aws : %w", err)
+	}
+	return sess, nil
+}
+
+//getAWSRegion retrieves region from cluster infrastructure
+func getAWSRegion(ctx context.Context, client client.Client) (string, error) {
+	infra := &configv1.Infrastructure{}
+	err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, infra)
+	if err != nil {
+		return "", fmt.Errorf("failed to get aws region : %w", err)
+	}
+	if infra.Status.PlatformStatus.Type != configv1.AWSPlatformType {
+		return "", fmt.Errorf("platform status %s is not %s", infra.Status.PlatformStatus.Type, configv1.AWSPlatformType)
+	}
+	return infra.Status.PlatformStatus.AWS.Region, nil
+}
+
+//getAWSCredentials retrieves credentials from secret namespace
+func getAWSCredentials(ctx context.Context, client client.Client) (string, string, error) {
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: awsCredsSecretName, Namespace: awsCredsNamespace}, secret); err != nil {
+		return "", "", fmt.Errorf("failed getting secret: %v from cluster: %w ", awsCredsSecretName, err)
+	}
+	awsAccessKeyID := string(secret.Data["aws_access_key_id"])
+	awsSecretAccessKey := string(secret.Data["aws_secret_access_key"])
+
+	if awsAccessKeyID == "" && awsSecretAccessKey == "" {
+		return "", "", errors.New("aws credentials secret can't be empty")
+	}
+	return awsAccessKeyID, awsSecretAccessKey, nil
+}
+
+// return resource identifier annotation from cr
+func getCROAnnotation(instance metav1.Object) (string, error) {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		return "", errors.New(fmt.Sprintf("annotations for %s can not be nil", instance.GetName()))
+	}
+
+	for k, v := range annotations {
+		if "resourceIdentifier" == k {
+			return v, nil
+		}
+	}
+	return "", errors.New(fmt.Sprintf("no resource identifier found for resource %s", instance.GetName()))
+}
+
+func getStrategyForResource(configMap *v1.ConfigMap, resourceType, tier string) (*strategyMap, error) {
+	rawStrategyMapping := configMap.Data[resourceType]
+	if rawStrategyMapping == "" {
+		return nil, fmt.Errorf("aws strategy for resource type: %s is not defined", resourceType)
+	}
+	var strategyMapping map[string]*strategyMap
+	if err := json.Unmarshal([]byte(rawStrategyMapping), &strategyMapping); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal strategy mapping for resource type %s: %v", resourceType, err)
+	}
+	if strategyMapping[tier] == nil {
+		return nil, fmt.Errorf("no strategy found for deployment type: %s and deployment tier: %s", resourceType, tier)
+	}
+	return strategyMapping[tier], nil
+}
+
+func putStrategyForResource(configMap *v1.ConfigMap, stratMap *strategyMap, resourceType, tier string) error {
+	rawStrategyMapping := configMap.Data[resourceType]
+	if rawStrategyMapping == "" {
+		return fmt.Errorf("aws strategy for resource type: %s is not defined", resourceType)
+	}
+	var strategyMapping map[string]*strategyMap
+	if err := json.Unmarshal([]byte(rawStrategyMapping), &strategyMapping); err != nil {
+		return fmt.Errorf("failed to unmarshal strategy mapping for resource type %s: %v", resourceType, err)
+	}
+	strategyMapping[tier] = stratMap
+	updatedRawStrategyMapping, err := json.Marshal(strategyMapping)
+	if err != nil {
+		return fmt.Errorf("failed to marshal strategy mapping for resource type %s: %v", resourceType, err)
+	}
+	configMap.Data[resourceType] = string(updatedRawStrategyMapping)
+	return nil
+}
+
+// GetClustersAvailableZones returns a map containing zone names that are currently available
+func GetClustersAvailableZones(nodes *v1.NodeList) map[string]bool {
+	zones := make(map[string]bool)
+	for _, node := range nodes.Items {
+		if isNodeWorkerAndReady(node) {
+			for labelName, labelValue := range node.Labels {
+				if labelName == "topology.kubernetes.io/zone" {
+					zones[labelValue] = true
+				}
+			}
+		}
+	}
+	return zones
+}

--- a/test/functional/aws_standalone_vpc.go
+++ b/test/functional/aws_standalone_vpc.go
@@ -1,0 +1,722 @@
+package functional
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/resources"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+
+	v1 "k8s.io/api/core/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+var (
+	resourceType    = "_network"
+	tier            = "production"
+	dummyIpAddress  = "172.11.0.0/24"
+	strategyMapName = "cloud-resources-aws-strategies"
+)
+
+type strategyMap struct {
+	CreateStrategy json.RawMessage `json:"createStrategy"`
+}
+
+// a custom error for reporting errors for each
+// network component
+type networkConfigTestError struct {
+	vpcError                  []error
+	subnetsError              []error
+	securityGroupError        []error
+	peeringConnError          []error
+	standaloneRouteTableError []error
+	clusterRouteTablesError   []error
+	rdsSubnetGroupsError      []error
+	cacheSubnetGroupsError    []error
+	updateCidrBlockError      []error
+}
+
+// pretty print the error message if there are any errors
+// this looks ugly but the output looks good!
+func (e *networkConfigTestError) Error() string {
+	var str strings.Builder
+	if len(e.vpcError) != 0 {
+		str.WriteString("\nVPC errors:")
+		for _, item := range e.vpcError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.subnetsError) != 0 {
+		str.WriteString("\nSubnet errors:")
+		for _, item := range e.subnetsError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.securityGroupError) != 0 {
+		str.WriteString("\nSecurity Group errors:")
+		for _, item := range e.securityGroupError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.peeringConnError) != 0 {
+		str.WriteString("\nPeering Connection errors:")
+		for _, item := range e.peeringConnError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.standaloneRouteTableError) != 0 {
+		str.WriteString("\nStandalone Route Table errors:")
+		for _, item := range e.standaloneRouteTableError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.clusterRouteTablesError) != 0 {
+		str.WriteString("\nCluster Route Table errors:")
+		for _, item := range e.clusterRouteTablesError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.rdsSubnetGroupsError) != 0 {
+		str.WriteString("\nRDS Subnet Groups errors:")
+		for _, item := range e.rdsSubnetGroupsError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.cacheSubnetGroupsError) != 0 {
+		str.WriteString("\nElasticache Subnet Groups errors:")
+		for _, item := range e.cacheSubnetGroupsError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	if len(e.updateCidrBlockError) != 0 {
+		str.WriteString("\nUpdate Cidr Block in AWS Strategy Map errors:")
+		for _, item := range e.updateCidrBlockError {
+			str.WriteString(fmt.Sprintf("\n\t%s", item.Error()))
+		}
+	}
+	return str.String()
+}
+
+// the error is valid if any of the error slices are not empty
+func (e *networkConfigTestError) hasError() bool {
+	return len(e.vpcError) != 0 ||
+		len(e.subnetsError) != 0 ||
+		len(e.securityGroupError) != 0 ||
+		len(e.peeringConnError) != 0 ||
+		len(e.standaloneRouteTableError) != 0 ||
+		len(e.clusterRouteTablesError) != 0 ||
+		len(e.rdsSubnetGroupsError) != 0 ||
+		len(e.cacheSubnetGroupsError) != 0 ||
+		len(e.updateCidrBlockError) != 0
+}
+
+// TestStandaloneVPCExists tests that the cloud resource operator network components
+// have been correctly set up and configured
+func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingContext) {
+	ctx := context.TODO()
+	testErrors := &networkConfigTestError{}
+
+	// create a new session
+	session, err := CreateAWSSession(ctx, testingCtx.Client)
+	if err != nil {
+		t.Fatal("could not create aws session", err)
+	}
+	ec2Sess := ec2.New(session)
+
+	// get the aws strategy map to get the vpc cidr block
+	// from the _network key
+	strategyMap := &v1.ConfigMap{}
+	err = testingCtx.Client.Get(ctx, types.NamespacedName{
+		Namespace: common.RHMIOperatorNamespace,
+		Name:      strategyMapName,
+	}, strategyMap)
+	if err != nil {
+		t.Fatal("could not get aws strategy map", err)
+	}
+
+	// get the create strategy for _network in the aws strategy configmap
+	// if this doesn't exist, skip the test completely since we're dealing
+	// with legacy cro networking
+	strat, err := getStrategyForResource(strategyMap, resourceType, tier)
+	if err != nil {
+		t.Skip("_network key does not exist in aws strategy configmap, skipping standalone vpc network test")
+	}
+
+	// get the vpc cidr block
+	expectedCidr, err := getCidrBlock(strat)
+	if err != nil {
+		t.Fatal("could not get cidr block", err)
+	}
+
+	// get the cluster id used for tagging aws resources
+	clusterTag, err := getClusterID(ctx, testingCtx.Client)
+	if err != nil {
+		t.Fatal("could not get cluster id", err)
+	}
+
+	clusterNodes := &v1.NodeList{}
+	err = testingCtx.Client.List(ctx, clusterNodes)
+	if err != nil {
+		t.Errorf("Error when getting the list of OpenShift cluster nodes: %s", err)
+	}
+	availableZones := GetClustersAvailableZones(clusterNodes)
+
+	// verify vpc
+	vpc, err := verifyVpc(ec2Sess, clusterTag, expectedCidr)
+	testErrors.vpcError = err.(*networkConfigTestError).vpcError
+
+	// fail immediately if the vpc is nil, since all of the
+	// other network components are associated with it
+	if vpc == nil {
+		t.Fatal(testErrors.Error())
+	}
+
+	// verify subnets
+	subnets, err := verifySubnets(ec2Sess, clusterTag, expectedCidr)
+	testErrors.subnetsError = err.(*networkConfigTestError).subnetsError
+
+	// verify security groups
+	err = verifySecurityGroup(ec2Sess, clusterTag)
+	testErrors.securityGroupError = err.(*networkConfigTestError).securityGroupError
+
+	// we have to manually construct the subnet group names for rds and elasticache,
+	// since tag filtering isnt currently available
+	subnetGroupName := resources.ShortenString(fmt.Sprintf("%s-%s", clusterTag, "subnet-group"), 40)
+
+	// build array list of all vpc private subnets
+	var subnetIDs []*string
+	for _, subnet := range subnets {
+		subnetIDs = append(subnetIDs, subnet.SubnetId)
+	}
+
+	// verify rds subnet groups
+	rdsSvc := rds.New(session)
+	err = verifyRdsSubnetGroups(rdsSvc, subnetGroupName, subnetIDs)
+	testErrors.rdsSubnetGroupsError = err.(*networkConfigTestError).rdsSubnetGroupsError
+
+	// verify elasticache subnet groups
+	cacheSvc := elasticache.New(session)
+	err = verifyCacheSubnetGroups(cacheSvc, subnetGroupName, subnetIDs)
+	testErrors.cacheSubnetGroupsError = err.(*networkConfigTestError).cacheSubnetGroupsError
+
+	// verify peering connection
+	conn, err := verifyPeeringConnection(ec2Sess, clusterTag, expectedCidr, aws.StringValue(vpc.VpcId))
+	testErrors.peeringConnError = err.(*networkConfigTestError).peeringConnError
+
+	// verify standalone vpc route table
+	err = verifyStandaloneRouteTable(ec2Sess, clusterTag, conn)
+	testErrors.standaloneRouteTableError = err.(*networkConfigTestError).standaloneRouteTableError
+
+	// verify cluster route table
+	err = verifyClusterRouteTables(ec2Sess, clusterTag, expectedCidr, conn, availableZones)
+	testErrors.clusterRouteTablesError = err.(*networkConfigTestError).clusterRouteTablesError
+
+	// update the _network create strategy in the aws strategy map and ensure
+	// this does not change the existing vpc
+	err = verifyCidrBlockUpdate(ctx, testingCtx, ec2Sess, strategyMap, clusterTag, expectedCidr)
+	testErrors.updateCidrBlockError = err.(*networkConfigTestError).updateCidrBlockError
+
+	// if any error was found, fail the test
+	if testErrors.hasError() {
+		t.Fatal(testErrors.Error())
+	}
+}
+
+// verify that the standalone vpc is created
+func verifyVpc(session *ec2.EC2, clusterTag, expectedCidr string) (*ec2.Vpc, error) {
+	newErr := &networkConfigTestError{
+		vpcError: []error{},
+	}
+
+	// filter vpcs by integreatly cluster id tag
+	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Values: []*string{aws.String(clusterTag)},
+			},
+		},
+	})
+	if err != nil {
+		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("could not find vpc: %v", err))
+		return nil, newErr
+	}
+
+	// only one vpc is expected
+	vpcs := describeVpcs.Vpcs
+	if len(vpcs) != 1 {
+		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("expected 1 vpc but found %d", len(vpcs)))
+		return nil, newErr
+	}
+
+	// cidr blocks should match
+	vpc := vpcs[0]
+	foundCidr := aws.StringValue(vpc.CidrBlock)
+	if foundCidr != expectedCidr {
+		errMsg := fmt.Errorf("expected vpc cidr block to match _network cidr block in aws strategy configmap. Expected %s, but got %s", expectedCidr, foundCidr)
+		newErr.vpcError = append(newErr.vpcError, errMsg)
+	}
+
+	return vpc, newErr
+}
+
+// verify that the vpc subnets are created
+func verifySubnets(session *ec2.EC2, clusterTag, expectedCidr string) ([]*ec2.Subnet, error) {
+	newErr := &networkConfigTestError{
+		subnetsError: []error{},
+	}
+
+	// filter subnets by integreatly cluster id tag
+	describeSubnets, err := session.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Values: []*string{aws.String(clusterTag)},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not describe subnets: %v", err)
+		newErr.subnetsError = append(newErr.subnetsError, errMsg)
+		return nil, newErr
+	}
+
+	// parse the vpc cidr block from the createStrategy for _network
+	subnets := describeSubnets.Subnets
+	_, cidr, err := net.ParseCIDR(expectedCidr)
+	if err != nil {
+		errMsg := fmt.Errorf("could not parse vpc cidr block: %v", err)
+		newErr.subnetsError = append(newErr.subnetsError, errMsg)
+		return subnets, newErr
+	}
+	cidrMask, _ := cidr.Mask.Size()
+
+	// verify the subnet masks for the subnets are one bit bigger
+	// than the vpc subnet mask
+	for _, subnet := range subnets {
+		_, subnetCidr, err := net.ParseCIDR(aws.StringValue(subnet.CidrBlock))
+		if err != nil {
+			errMsg := fmt.Errorf("could not parse subnet mask for vpc subnets: %v", err)
+			newErr.subnetsError = append(newErr.subnetsError, errMsg)
+			return subnets, newErr
+		}
+		subnetCidrMask, _ := subnetCidr.Mask.Size()
+		if subnetCidrMask != cidrMask+1 {
+			errMsg := fmt.Errorf("subnet mask expect to be 1 bit greater than vpc subnet mask, found: %d, expected %d", subnetCidrMask, cidrMask+1)
+			newErr.subnetsError = append(newErr.subnetsError, errMsg)
+		}
+	}
+
+	return subnets, newErr
+}
+
+// verify vpc security group
+func verifySecurityGroup(session *ec2.EC2, clusterTag string) error {
+	newErr := &networkConfigTestError{
+		securityGroupError: []error{},
+	}
+
+	// filter security groups by integreatly cluster id tag
+	describeGroups, err := session.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Values: []*string{aws.String(clusterTag)},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not find vpc security group: %v", err)
+		newErr.securityGroupError = append(newErr.securityGroupError, errMsg)
+	}
+
+	// expect 1 security group
+	secGroups := describeGroups.SecurityGroups
+	if len(secGroups) != 1 {
+		errMsg := fmt.Errorf("unexpected number of security groups: %d", len(secGroups))
+		newErr.securityGroupError = append(newErr.securityGroupError, errMsg)
+		return newErr
+	}
+
+	return newErr
+}
+
+// verify that the subnet groups for rds are created
+func verifyRdsSubnetGroups(rdsSess *rds.RDS, name string, subnets []*string) error {
+	newErr := &networkConfigTestError{
+		rdsSubnetGroupsError: []error{},
+	}
+
+	// get rds subnet groups by subnet group name
+	describeGroups, err := rdsSess.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: aws.String(name),
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("error describing rds subnet groups: %v", err)
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	// expect 1 subnet group
+	subnetGroups := describeGroups.DBSubnetGroups
+	if len(subnetGroups) != 1 {
+		errMsg := fmt.Errorf("unexpected number of rds subnet groups: %d", len(subnetGroups))
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	// ensure all subnets exist in subnet group
+	subnetsExist := true
+	for _, subnet := range subnetGroups[0].Subnets {
+		if !contains(subnets, subnet.SubnetIdentifier) {
+			subnetsExist = false
+			break
+		}
+	}
+	if !subnetsExist {
+		errMsg := fmt.Errorf("rds subnet group does not contain expected subnets: %s, %s", aws.StringValue(subnets[0]), aws.StringValue(subnets[1]))
+		newErr.rdsSubnetGroupsError = append(newErr.rdsSubnetGroupsError, errMsg)
+	}
+
+	return newErr
+}
+
+// verify that the subnet groups for elasticache are created
+func verifyCacheSubnetGroups(cacheSvc *elasticache.ElastiCache, name string, subnets []*string) error {
+	newErr := &networkConfigTestError{
+		cacheSubnetGroupsError: []error{},
+	}
+
+	// get elasticache subnet groups by subnet group name
+	describeCacheGroups, err := cacheSvc.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{
+		CacheSubnetGroupName: aws.String(name),
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("error describing elasticache subnet groups: %v", err)
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+		return newErr
+	}
+
+	// expect 1 subnet group
+	cacheSubnetGroups := describeCacheGroups.CacheSubnetGroups
+	if len(cacheSubnetGroups) != 1 {
+		errMsg := fmt.Errorf("unexpected number of elasticache subnet groups: %d", len(cacheSubnetGroups))
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+	}
+
+	// ensure all subnets exist in subnet group
+	subnetsExist := true
+	for _, subnet := range cacheSubnetGroups[0].Subnets {
+		if !contains(subnets, subnet.SubnetIdentifier) {
+			subnetsExist = false
+			break
+		}
+	}
+	if !subnetsExist {
+		errMsg := fmt.Errorf("elasticache subnet group does not contain expected subnets: %s, %s", aws.StringValue(subnets[0]), aws.StringValue(subnets[1]))
+		newErr.cacheSubnetGroupsError = append(newErr.cacheSubnetGroupsError, errMsg)
+	}
+
+	return newErr
+}
+
+// verify that the peering connection we create has the correct requester info
+func verifyPeeringConnection(session *ec2.EC2, clusterTag, expectedCidr, vpcID string) (*ec2.VpcPeeringConnection, error) {
+	newErr := &networkConfigTestError{
+		peeringConnError: []error{},
+	}
+
+	// filter the peering connections by integreatly cluster id tag
+	peeringConn, err := session.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Values: []*string{aws.String(clusterTag)},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not describe peering connections: %v", err)
+		newErr.peeringConnError = append(newErr.peeringConnError, errMsg)
+		return nil, newErr
+	}
+
+	// expect 1 peering connection to be found
+	conns := peeringConn.VpcPeeringConnections
+	if len(conns) != 1 {
+		errMsg := fmt.Errorf("unexpected number of vpc peering connections: %d", len(conns))
+		newErr.peeringConnError = append(newErr.peeringConnError, errMsg)
+		return nil, newErr
+	}
+
+	// verify that the requester info is correct
+	conn := conns[0]
+	if aws.StringValue(conn.RequesterVpcInfo.CidrBlock) != expectedCidr && aws.StringValue(conn.RequesterVpcInfo.VpcId) != vpcID {
+		errMsg := fmt.Errorf("unexpected accepter vpc cidr block: %d", len(conns))
+		newErr.peeringConnError = append(newErr.peeringConnError, errMsg)
+	}
+
+	// verify the peering connection state is active
+	if aws.StringValue(conn.Status.Code) != ec2.VpcPeeringConnectionStateReasonCodeActive {
+		errMsg := fmt.Errorf("unexpected peering connection status: %s", aws.StringValue(conn.Status.Code))
+		newErr.peeringConnError = append(newErr.peeringConnError, errMsg)
+	}
+
+	return conn, newErr
+}
+
+// verify that the standalone route table contains a route to the peering connection
+func verifyStandaloneRouteTable(session *ec2.EC2, clusterTag string, conn *ec2.VpcPeeringConnection) error {
+	newErr := &networkConfigTestError{
+		standaloneRouteTableError: []error{},
+	}
+
+	// filter the route tables by integreatly cluster id tag
+	describeRouteTables, err := session.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Values: []*string{aws.String(clusterTag)},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not describe route tables: %v", err)
+		newErr.standaloneRouteTableError = append(newErr.standaloneRouteTableError, errMsg)
+		return newErr
+	}
+
+	// expect 1 route table
+	routeTables := describeRouteTables.RouteTables
+	if len(routeTables) != 1 {
+		errMsg := fmt.Errorf("unexpected number of route tables: %d", len(routeTables))
+		newErr.standaloneRouteTableError = append(newErr.standaloneRouteTableError, errMsg)
+		return newErr
+	}
+
+	// verify that the route table has a route to the peering connection
+	foundRoute := false
+	for _, route := range routeTables[0].Routes {
+		if aws.StringValue(route.VpcPeeringConnectionId) == aws.StringValue(conn.VpcPeeringConnectionId) {
+			foundRoute = true
+		}
+	}
+	if !foundRoute {
+		errMsg := fmt.Errorf("did not find expected route with peering connection: %s", aws.StringValue(conn.VpcPeeringConnectionId))
+		newErr.standaloneRouteTableError = append(newErr.standaloneRouteTableError, errMsg)
+	}
+
+	return newErr
+}
+
+// verify that the cluster route tables contain a route to the peering connection and the standalone vpc
+func verifyClusterRouteTables(session *ec2.EC2, clusterTag, vpcCidr string, peeringConn *ec2.VpcPeeringConnection, availableZones map[string]bool) error {
+	newErr := &networkConfigTestError{
+		clusterRouteTablesError: []error{},
+	}
+
+	// filter the route tables by kubernetes owner id
+	describeRouteTables, err := session.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", clusterTag)),
+				Values: []*string{aws.String("owned")},
+			},
+		},
+	})
+	if err != nil {
+		errMsg := fmt.Errorf("could not describe route tables: %v", err)
+		newErr.clusterRouteTablesError = append(newErr.clusterRouteTablesError, errMsg)
+		return newErr
+	}
+
+	// 1 private route per AZ + 1 public route
+	expectedRouteTableCount := len(availableZones) + 1
+	routeTables := describeRouteTables.RouteTables
+	if len(routeTables) != expectedRouteTableCount {
+		errMsg := fmt.Errorf("unexpected number of route tables: %d", len(routeTables))
+		newErr.clusterRouteTablesError = append(newErr.clusterRouteTablesError, errMsg)
+		return newErr
+	}
+
+	// verify that each route table has a route to
+	// the peering connection
+	for _, routeTable := range routeTables {
+		foundRoute := false
+		for _, route := range routeTable.Routes {
+			if aws.StringValue(route.DestinationCidrBlock) == vpcCidr &&
+				aws.StringValue(route.VpcPeeringConnectionId) == aws.StringValue(peeringConn.VpcPeeringConnectionId) {
+				foundRoute = true
+			}
+		}
+		if !foundRoute {
+			tableID := aws.StringValue(routeTable.RouteTableId)
+			errMsg := fmt.Errorf("expected route for cluster route table %s not found", tableID)
+			newErr.clusterRouteTablesError = append(newErr.clusterRouteTablesError, errMsg)
+		}
+	}
+
+	return newErr
+}
+
+// verify no new vpc is created when the cidr block is updated in the _network section of the aws
+// strategy map
+func verifyCidrBlockUpdate(ctx context.Context, testingCtx *common.TestingContext, session *ec2.EC2, stratMap *v1.ConfigMap, clusterTag, expectedCidr string) error {
+	newErr := &networkConfigTestError{
+		updateCidrBlockError: []error{},
+	}
+
+	// get _network resource type
+	strat, err := getStrategyForResource(stratMap, resourceType, tier)
+
+	if err != nil {
+		errMsg := fmt.Errorf("failed to get strategy for _network: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// get create config
+	vpcCreateConfig := &ec2.CreateVpcInput{}
+	if err := json.Unmarshal(strat.CreateStrategy, vpcCreateConfig); err != nil {
+		errMsg := fmt.Errorf("failed to unmarshal create config: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	originalCidrBlock := *vpcCreateConfig.CidrBlock
+
+	// update the cidr block
+	vpcCreateConfig.CidrBlock = aws.String(dummyIpAddress)
+
+	// marshal create config
+	bytesOutput, err := json.Marshal(vpcCreateConfig)
+	if err != nil {
+		errMsg := fmt.Errorf("failed to unmarshal create config: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// update the ip address in the _network create strategy
+	if err = putStrategyForResource(stratMap, &strategyMap{CreateStrategy: bytesOutput}, resourceType, tier); err != nil {
+		errMsg := fmt.Errorf("failed to update strategy map for _network create strategy: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// update config map
+	if err := testingCtx.Client.Update(ctx, stratMap); err != nil {
+		errMsg := fmt.Errorf("failed to update aws strategy map: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// wait 120 seconds for any changes to be reconciled
+	pollErr := wait.PollImmediate(15*time.Second, 2*time.Minute, func() (bool, error) {
+		vpcOutput, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("tag:integreatly.org/clusterID"),
+					Values: []*string{aws.String(clusterTag)},
+				},
+			},
+		})
+		if err != nil {
+			return false, err
+		}
+		if len(vpcOutput.Vpcs) != 1 {
+			return false, fmt.Errorf("unexpected number of vpcs found: %d", len(vpcOutput.Vpcs))
+		}
+		foundVpc := vpcOutput.Vpcs[0]
+		foundCidr := aws.StringValue(foundVpc.CidrBlock)
+		if foundCidr != expectedCidr {
+			return false, fmt.Errorf("expected vpc cidr block to match _network cidr block in aws strategy configmap. Expected %s, but got %s", expectedCidr, foundCidr)
+		}
+		return false, nil
+	})
+
+	// update the vpc CIDR block back to its original value
+	// update the cidr block
+	vpcCreateConfig.CidrBlock = aws.String(originalCidrBlock)
+
+	// marshal create config
+	bytesOutput, err = json.Marshal(vpcCreateConfig)
+	if err != nil {
+		errMsg := fmt.Errorf("failed to unmarshal create config: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// update the ip address in the _network create strategy
+	if err = putStrategyForResource(stratMap, &strategyMap{CreateStrategy: bytesOutput}, resourceType, tier); err != nil {
+		errMsg := fmt.Errorf("failed to update strategy map for _network create strategy: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	// update config map
+	if err := testingCtx.Client.Update(ctx, stratMap); err != nil {
+		errMsg := fmt.Errorf("failed to update aws strategy map: %w", err)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	if pollErr != nil {
+		// if the poll timed out, the vpc cidr block did not change,
+		// so don't return any error
+		if strings.Contains(pollErr.Error(), "timed out") {
+			return newErr
+		}
+
+		errMsg := fmt.Errorf("unexpected error updating cidr block in aws strategy map: %w", pollErr)
+		newErr.updateCidrBlockError = append(newErr.updateCidrBlockError, errMsg)
+		return newErr
+	}
+
+	return newErr
+}
+
+func getClusterID(ctx context.Context, client client.Client) (string, error) {
+	infra := &configv1.Infrastructure{}
+	err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, infra)
+	if err != nil {
+		return "", fmt.Errorf("failed to get aws region: %w", err)
+	}
+	return infra.Status.InfrastructureName, nil
+}
+
+func getCidrBlock(strat *strategyMap) (string, error) {
+	vpcCreateConfig := &ec2.CreateVpcInput{}
+	if err := json.Unmarshal(strat.CreateStrategy, vpcCreateConfig); err != nil {
+		return "", err
+	}
+	if vpcCreateConfig.CidrBlock == nil {
+		return "", fmt.Errorf("cidr block cannot be empty")
+	}
+	return aws.StringValue(vpcCreateConfig.CidrBlock), nil
+}
+
+func contains(strs []*string, str *string) bool {
+	for _, s := range strs {
+		if aws.StringValue(str) == aws.StringValue(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/functional/aws_strategy_override.go
+++ b/test/functional/aws_strategy_override.go
@@ -1,0 +1,233 @@
+package functional
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/common"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+	This test is to verify that changes made to the RHMI config are reflected in the
+	Cloud Resource Operator (CRO) strategy override config map
+	And further reflected in the AWS resource
+	RHMI config allows for Maintenance and Backup times
+	We need to ensure these windows are built and updated in the config map
+
+	We currently have tests A18 and A21 where we test the validation of the RHMI config
+	And the updating of the CRO strategy override config map
+	We will be using this test to full test e2e from updating the config to changing the values in AWS
+*/
+
+type strategytestCase struct {
+	RHMIConfigValues  common.MaintenanceBackup
+	backupWindow      string
+	maintenanceWindow string
+}
+
+var strategyTestCases = []strategytestCase{
+	{
+		RHMIConfigValues: common.MaintenanceBackup{
+			Backup: v1alpha1.Backup{
+				ApplyOn: "20:00",
+			},
+			Maintenance: v1alpha1.Maintenance{
+				ApplyFrom: "sun 21:01",
+			},
+		},
+		backupWindow:      "20:00-21:00",
+		maintenanceWindow: "sun:21:01-sun:22:01",
+	},
+}
+
+// tests e2e cro strategy override
+func CROStrategyOverrideAWSResourceTest(t common.TestingTB, testingContext *common.TestingContext) {
+	ctx := context.TODO()
+	var testErrors []string
+
+	// rhmi config we need to use is the rhmi config provisioned in the RHMI install
+	// this to avoid a conflict of having multiple rhmi configs
+	rhmiConfig := common.RHMIConfigTemplate()
+
+	for _, test := range strategyTestCases {
+		// update rhmi config Backup and Maintenance times to valid expected times
+		if err := common.UpdateRHMIConfigBackupAndMaintenance(ctx, testingContext.Client, rhmiConfig, test.RHMIConfigValues); err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("\nunable to update rhmi config : %v", err))
+			continue
+		}
+
+		// ensure strategy config map is as expected
+		// we have added this poll to allow the operator reconcile on the cr and update the strategy override
+		// we expect the change to be immediate, the poll is help with any potential test flake
+		// continue to poll until no error or timeout - on timeout we handle the polling error
+		var lastPollError error
+		if err := wait.PollImmediate(time.Second*5, time.Second*30, func() (done bool, err error) {
+			lastPollError = common.VerifyCROStrategyMap(ctx, testingContext.Client, test.backupWindow, test.maintenanceWindow)
+			if lastPollError == nil {
+				return true, nil
+			}
+			return false, nil
+		}); err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("\ntest failure : %s : %v", lastPollError, err))
+		}
+
+		// we need to verify if the rds instance have been updated to reflect the new backup and maintenance windows
+		// as we need to wait for the Cloud Resource Operator to reconcile on each RDS resource it may take some time for the windows to be updated
+		// continue to poll until no error or timeout - on timeout we handle the polling error
+		if err := wait.PollImmediate(time.Second*30, time.Second*300, func() (done bool, err error) {
+			lastPollError = verifyRDSMaintenanceBackupWindows(ctx, testingContext.Client, test.backupWindow, test.maintenanceWindow)
+			if lastPollError == nil {
+				return true, nil
+			}
+			return false, nil
+
+		}); err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("\ntest failure : %s : %v", lastPollError, err))
+		}
+
+		// we need to verify if the elasticache instance have been updated to reflect the new backup and maintenance windows
+		// as we need to wait for the Cloud Resource Operator to reconcile on each RDS resource it may take some time for the windows to be updated
+		// continue to poll until no error or timeout - on timeout we handle the polling error
+		if err := wait.PollImmediate(time.Second*30, time.Second*300, func() (done bool, err error) {
+			lastPollError = verifyElasticacheMaintenanceBackupWindows(ctx, testingContext.Client, test.backupWindow, test.maintenanceWindow)
+			if lastPollError == nil {
+				return true, nil
+			}
+			return false, nil
+		}); err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("\ntest failure : %s : %v", lastPollError, err))
+		}
+	}
+
+	if len(testErrors) != 0 {
+		t.Fatalf("strategy override test failed : \n%s", testErrors)
+	}
+}
+
+/*
+	From a list of ResourceID's we iterate through them
+	For every resource we describe the resource, checking the backup and maintenance windows are as expected
+	We build a list of errors, to ensure we catch every verification
+	If there is an error we return the list as an error
+*/
+func verifyRDSMaintenanceBackupWindows(ctx context.Context, client client.Client, expectedBackupWindow, expectedMaintenanceWindow string) error {
+
+	rhmi, err := common.GetRHMI(client, true)
+	if err != nil {
+		return err
+	}
+
+	// build an array of postgres resources to check and an array of test errors
+	rdsResourceIDs, testErrors := GetRDSResourceIDs(ctx, client, rhmi)
+
+	// check for errors from getting rds resource ids
+	// if there is any errors we return as we can not continue the test with out all expected resources
+	if len(testErrors) != 0 {
+		return fmt.Errorf("verify rds maintenance and backup windows failed with the following errors : \n%s", testErrors)
+	}
+
+	// create aws session
+	sess, err := CreateAWSSession(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to create aws session: %v", err)
+	}
+	rdsapi := rds.New(sess)
+
+	// check every rds instance backup and maintenance windows are as expected resource
+	for _, resourceIdentifier := range rdsResourceIDs {
+		// get the rds instance
+		foundRDSInstances, err := rdsapi.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: aws.String(resourceIdentifier),
+		})
+		if err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("failed to get rds instance :%s with error : %v", resourceIdentifier, err))
+			continue
+		}
+		// verify the rds instance is as expected
+		instance := *foundRDSInstances.DBInstances[0]
+		if *instance.PreferredMaintenanceWindow != expectedMaintenanceWindow {
+			testErrors = append(testErrors, fmt.Sprintf("\tresource found : %s : found maintenance window : %s : expected maintenance window : %s\n", *instance.DBInstanceIdentifier, *instance.PreferredMaintenanceWindow, expectedMaintenanceWindow))
+		}
+		if *instance.PreferredBackupWindow != expectedBackupWindow {
+			testErrors = append(testErrors, fmt.Sprintf("\tresource found : %s : found backup window : %s : expected backup window : %s\n", *instance.DBInstanceIdentifier, *instance.PreferredBackupWindow, expectedBackupWindow))
+
+		}
+	}
+
+	// check for any errors
+	if len(testErrors) != 0 {
+		return fmt.Errorf("verify rds maintenance and backup windows failed with the following errors : \n%s", testErrors)
+	}
+	return nil
+}
+
+/*
+	From a list of ResourceID's we iterate through them
+	For every resource we describe the resource, checking the backup and maintenance windows are as expected
+	We build a list of errors, to ensure we catch every verification
+	If there is an error we return the list as an error
+*/
+func verifyElasticacheMaintenanceBackupWindows(ctx context.Context, client client.Client, expectedBackupWindow, expectedMaintenanceWindow string) error {
+	rhmi, err := common.GetRHMI(client, true)
+	if err != nil {
+		return err
+	}
+
+	// build an array of redis resources to check and test error array
+	elasticacheResourceIDs, testErrors := GetElasticacheResourceIDs(ctx, client, rhmi)
+
+	// check for errors from getting rds resource ids
+	// if there is any errors we return as we can not continue the test with out all expected resources
+	if len(testErrors) != 0 {
+		return fmt.Errorf("test elasticache maintenance and backup windows failed with the following errors : \n%s", testErrors)
+	}
+
+	// create AWS session
+	sess, err := CreateAWSSession(ctx, client)
+	if err != nil {
+		return fmt.Errorf("failed to create aws session: %v", err)
+	}
+	elasticacheapi := elasticache.New(sess)
+
+	// check each elasticache maintenance and backup windows are as expected
+	// we need to used elasticache clusters as it is the only way we can return both maintenance and snapshot windows
+	// see * https://docs.aws.amazon.com/sdk-for-go/api/service/elasticache/#DescribeCacheClustersOutput
+	// The cloud resource operator (CRO) provisions a replication group
+	// A replication group is made up of two nodes, each node is a cache cluster
+	// Describing cache clusters we get more fine grained information about each node
+	foundElasticacheClusters, err := elasticacheapi.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{})
+	if err != nil {
+		testErrors = append(testErrors, fmt.Sprintf("failed to get elasticache cache clusters with error : %v", err))
+	}
+
+	// we need to iterate through each resource ID
+	for _, resourceID := range elasticacheResourceIDs {
+		// we need to iterate through each cache cluster
+		for _, cacheCluster := range foundElasticacheClusters.CacheClusters {
+			// if a cache cluster does not match our resource id we can break out
+			if *cacheCluster.ReplicationGroupId != resourceID {
+				continue
+			}
+			// check cache cluster maintenance and backup windows are as expected
+			if *cacheCluster.PreferredMaintenanceWindow != expectedMaintenanceWindow {
+				testErrors = append(testErrors, fmt.Sprintf("\tresource found : %s : found maintenance window : %s : expected maintenance window : %s\n", *cacheCluster.ReplicationGroupId, *cacheCluster.PreferredMaintenanceWindow, expectedMaintenanceWindow))
+			}
+			if *cacheCluster.SnapshotWindow != expectedBackupWindow {
+				testErrors = append(testErrors, fmt.Sprintf("\tresource found : %s : found snapshot window : %s : expected snapshot window : %s\n", *cacheCluster.ReplicationGroupId, *cacheCluster.SnapshotWindow, expectedBackupWindow))
+			}
+		}
+	}
+
+	// check for any errors
+	if len(testErrors) != 0 {
+		return fmt.Errorf("verify elasticache maintenance and snapshot windows failed with the following errors : \n%s", testErrors)
+	}
+	return nil
+}

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -1,0 +1,78 @@
+package functional
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("integreatly", func() {
+
+	var (
+		restConfig = cfg
+		t          = GinkgoT()
+	)
+
+	BeforeEach(func() {
+		restConfig = cfg
+		t = GinkgoT()
+	})
+
+	RunTests := func() {
+
+		// get all automated tests
+		tests := []common.Tests{
+			{
+				Type:      "ALL TESTS",
+				TestCases: common.ALL_TESTS,
+			},
+			{
+				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
+				TestCases: common.GetHappyPathTestCases(installType),
+			},
+			{
+				Type:      fmt.Sprintf("%s IDP BASED", installType),
+				TestCases: common.GetIDPBasedTestCases(installType),
+			},
+			{
+				Type:      fmt.Sprintf("%s Functional", installType),
+				TestCases: FUNCTIONAL_TESTS,
+			},
+		}
+
+		if os.Getenv("MULTIAZ") != "true" {
+			tests = append(tests, common.Tests{
+				Type:      fmt.Sprintf("%s Multi AZ", installType),
+				TestCases: MULTIAZ_TESTS,
+			})
+		}
+
+		if os.Getenv("DESTRUCTIVE") == "true" {
+			tests = append(tests, common.Tests{
+				Type:      "Destructive Tests",
+				TestCases: common.DESTRUCTIVE_TESTS,
+			})
+		}
+
+		for _, test := range tests {
+			Context(test.Type, func() {
+				for _, testCase := range test.TestCases {
+					currentTest := testCase
+					It(currentTest.Description, func() {
+						testingContext, err := common.NewTestingContext(restConfig)
+						if err != nil {
+							t.Fatal("failed to create testing context", err)
+						}
+						currentTest.Test(t, testingContext)
+					})
+				}
+			})
+		}
+
+	}
+
+	RunTests()
+
+})

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -1,0 +1,159 @@
+package functional
+
+import (
+	goctx "context"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	v1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	namespacesToCheck = []string{
+		common.RHSSOUserProductOperatorNamespace,
+		common.RHSSOProductNamespace,
+		common.ThreeScaleProductNamespace,
+	}
+	availableZones = map[string]bool{}
+)
+
+type podDistribution struct {
+	zones     map[string]int
+	podsTotal int
+	namespace string
+}
+
+func TestMultiAZPodDistribution(t common.TestingTB, ctx *common.TestingContext) {
+	var testErrors []string
+	pods := &v1.PodList{}
+	nodes := &v1.NodeList{}
+
+	ctx.Client.List(goctx.TODO(), nodes)
+
+	availableZones = GetClustersAvailableZones(nodes)
+
+	// If "NAMESPACES_TO_CHECK" env var contains a list of namespaces, use that instead of the predefined list
+	namespacesFromEnvVar := os.Getenv("NAMESPACES_TO_CHECK")
+	if namespacesFromEnvVar != "" {
+		namespacesToCheck = strings.Split(namespacesFromEnvVar, ",")
+	}
+
+	for _, ns := range namespacesToCheck {
+		distributionPerOwner := make(map[string]*podDistribution)
+		// Get a list of pods per namespace
+		err := ctx.Client.List(goctx.TODO(), pods, k8sclient.InNamespace(ns))
+		if err != nil {
+			testErrors = append(testErrors, fmt.Sprintf("Can't list pods in the namespace %s, %v", ns, err))
+			continue
+		}
+		if len(pods.Items) == 0 {
+			testErrors = append(testErrors, fmt.Sprintf("A namespace '%s' doesn't contain any pods", ns))
+			continue
+		}
+		for _, pod := range pods.Items {
+			// Skip pods with status "Completed"
+			if pod.Status.Phase == "Succeeded" {
+				continue
+			}
+			// Get an owner of the pod (ReplicationController, StatefulSet, ...)
+			podOwnerName := pod.OwnerReferences[0].Name
+			// Get a pod's AZ it is currently running in
+			podsAz := getPodZoneName(pod, nodes)
+			// Update the pod distribution for the pods' owner
+			if _, ok := distributionPerOwner[podOwnerName]; ok == false {
+				distributionPerOwner[podOwnerName] = &podDistribution{
+					zones:     map[string]int{podsAz: 1},
+					podsTotal: 1,
+					namespace: ns,
+				}
+			} else {
+				distributionPerOwner[podOwnerName].podsTotal++
+				distributionPerOwner[podOwnerName].zones[podsAz]++
+			}
+
+		}
+		testErrors = append(testErrors, testCorrectPodDistribution(distributionPerOwner)...)
+	}
+
+	if len(testErrors) != 0 {
+		t.Fatalf("\nError when verifying the pod distribution: \n%s", testErrors)
+	}
+}
+
+// Returns true if the node is a "worker" (compute node)
+// and is marked as Ready
+func isNodeWorkerAndReady(node v1.Node) bool {
+	var isWorker bool
+
+	for annKey, annValue := range node.Annotations {
+		if annKey == "machine.openshift.io/machine" && strings.Contains(annValue, "worker") {
+			isWorker = true
+			break
+		}
+	}
+
+	if isWorker {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "True" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Returns an AWS zone the pod is currently running in
+func getPodZoneName(pod v1.Pod, nodes *v1.NodeList) string {
+	for _, node := range nodes.Items {
+		if pod.Spec.NodeName == node.Name {
+			for labelName, labelValue := range node.Labels {
+				if labelName == "topology.kubernetes.io/zone" {
+					return labelValue
+				}
+
+			}
+		}
+	}
+	return ""
+}
+
+// Test whether the pod distribution (per pod owner) is correct
+// and return a slice of errors (strings) if any was encountered
+// Verify that all pods are not on the same zone with the exception of
+// replica count = 1
+func testCorrectPodDistribution(dist map[string]*podDistribution) []string {
+	var testErrors []string
+	for podOwner, pd := range dist {
+		if pd.podsTotal > 1 {
+			for _, n := range pd.zones {
+				if n == pd.podsTotal {
+					testErrors = append(testErrors, fmt.Sprintf("Pod owner '%s'. All Pods are on the same zone. %+v\n", podOwner, pd))
+					break
+				}
+			}
+		}
+	}
+	return testErrors
+
+}
+
+// Takes the total number of pods belonging to the pod owner
+// and calculates the minimal and maximal amount of pods that should be running
+// per zone to meet the criteria for uniform pod distribution across the zones
+// Examples:
+// - 5 pods, 3 zones => 5/3 => min 1, max 2 pods per zone
+// - 4 pods, 2 zones => 4/2 => min 2, max 2 pods per zone
+func getAllowedNumberOfPodsPerZone(podsTotal int) (min int, max int) {
+	if podsTotal%len(availableZones) == 0 {
+		min = podsTotal / len(availableZones)
+		max = min
+		return
+	}
+	min = int(math.Floor(float64(podsTotal) / float64(len(availableZones))))
+	max = min + 1
+	return
+}

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -1,0 +1,85 @@
+package functional
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+const (
+	testResultsDirectory = "/test-run-results"
+	jUnitOutputFilename  = "junit-integreatly-operator.xml"
+	addonMetadataName    = "addon-metadata.json"
+	testOutputFileName   = "test-output.txt"
+	testSuiteName        = "integreatly-operator"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var installType string
+var err error
+
+func TestAPIs(t common.TestingTB) {
+	RegisterFailHandler(Fail)
+
+	// start test env
+	By("bootstrapping test environment")
+
+	useCluster := true
+	testEnv = &envtest.Environment{
+		UseExistingCluster:       &useCluster,
+		AttachControlPlaneOutput: true,
+	}
+	cfg, err = testEnv.Start()
+	if err != nil {
+		t.Fatalf("could not get start test environment %s", err)
+	}
+	//TODO: Trigger operator install
+
+	//TODO: validate operator has completed install
+
+	// get install type
+	installType, err = common.GetInstallType(cfg)
+	if err != nil {
+		t.Fatalf("could not get install type %s", err)
+	}
+
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s/%s", testResultsDirectory, jUnitOutputFilename))
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Functional Test Suite",
+		[]Reporter{junitReporter})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	err = rhmiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	close(done)
+}, 120)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/functional/tests.go
+++ b/test/functional/tests.go
@@ -1,0 +1,17 @@
+package functional
+
+import "github.com/integr8ly/integreatly-operator/test/common"
+
+var (
+	FUNCTIONAL_TESTS = []common.TestCase{
+		{Description: "F01 - Verify AWS rds resources exist and are in expected state", Test: AWSRDSResourcesExistTest},
+		{Description: "F03 - Verify AWS elasticache resources exist and are in expected state", Test: AWSElasticacheResourcesExistTest},
+		{Description: "A21 - Verify AWS maintenance and backup windows", Test: CROStrategyOverrideAWSResourceTest},
+		{Description: "A25 - Verify standalone RHMI VPC exists and is configured properly", Test: TestStandaloneVPCExists},
+		{Description: "N06 - Verify Legacy cluster VPC is configured properly", Test: TestLegacyClusterVPC},
+		{Description: "F04 - Verify AWS s3 blob storage resources exist", Test: TestAWSs3BlobStorageResourcesExist},
+	}
+	MULTIAZ_TESTS = []common.TestCase{
+		{Description: "F09 - Verify correct pod distribution on Multi-AZ cluster", Test: TestMultiAZPodDistribution},
+	}
+)

--- a/test/metadata/metadata.go
+++ b/test/metadata/metadata.go
@@ -1,0 +1,31 @@
+package metadata
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+// metadata houses metadata to be written out to the additional-metadata.json
+type metadata struct {
+	// Whether the CRD was found. Typically Spyglass seems to have issues displaying non-strings, so
+	// this will be written out as a string despite the native JSON boolean type.
+	FoundCRD bool `json:"found-crd,string"`
+}
+
+// Instance is the singleton instance of metadata.
+var Instance = metadata{}
+
+// WriteToJSON will marshall the metadata struct and write it into the given file.
+func (m *metadata) WriteToJSON(outputFilename string) (err error) {
+	var data []byte
+	if data, err = json.Marshal(m); err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(outputFilename, data, os.FileMode(0644)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/osde2e/managed_api_test.go
+++ b/test/osde2e/managed_api_test.go
@@ -1,0 +1,87 @@
+package osde2e
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("integreatly", func() {
+
+	var (
+		restConfig = cfg
+		t          = GinkgoT()
+	)
+
+	BeforeEach(func() {
+		restConfig = cfg
+		t = GinkgoT()
+	})
+
+	RunTests := func() {
+
+		os.Setenv("WATCH_NAMESPACE", "redhat-rhoam-operator")
+		os.Setenv("SKIP_FLAKES", "true")
+		common.NamespacePrefix = "redhat-rhoam-"
+		common.RHMIOperatorNamespace = common.NamespacePrefix + "operator"
+		common.MonitoringOperatorNamespace = common.NamespacePrefix + "middleware-monitoring-operator"
+		common.MonitoringFederateNamespace = common.NamespacePrefix + "middleware-monitoring-federate"
+		common.AMQOnlineOperatorNamespace = common.NamespacePrefix + "amq-online"
+		common.ApicurioRegistryProductNamespace = common.NamespacePrefix + "apicurio-registry"
+		common.ApicurioRegistryOperatorNamespace = common.ApicurioRegistryProductNamespace + "-operator"
+		common.ApicuritoProductNamespace = common.NamespacePrefix + "apicurito"
+		common.ApicuritoOperatorNamespace = common.ApicuritoProductNamespace + "-operator"
+		common.CloudResourceOperatorNamespace = common.NamespacePrefix + "cloud-resources-operator"
+		common.CodeReadyProductNamespace = common.NamespacePrefix + "codeready-workspaces"
+		common.CodeReadyOperatorNamespace = common.CodeReadyProductNamespace + "-operator"
+		common.FuseProductNamespace = common.NamespacePrefix + "fuse"
+		common.FuseOperatorNamespace = common.FuseProductNamespace + "-operator"
+		common.RHSSOUserProductOperatorNamespace = common.NamespacePrefix + "user-sso"
+		common.RHSSOUserOperatorNamespace = common.RHSSOUserProductOperatorNamespace + "-operator"
+		common.RHSSOProductNamespace = common.NamespacePrefix + "rhsso"
+		common.RHSSOOperatorNamespace = common.RHSSOProductNamespace + "-operator"
+		common.SolutionExplorerProductNamespace = common.NamespacePrefix + "solution-explorer"
+		common.SolutionExplorerOperatorNamespace = common.SolutionExplorerProductNamespace + "-operator"
+		common.ThreeScaleProductNamespace = common.NamespacePrefix + "3scale"
+		common.ThreeScaleOperatorNamespace = common.ThreeScaleProductNamespace + "-operator"
+		common.UPSProductNamespace = common.NamespacePrefix + "ups"
+		common.UPSOperatorNamespace = common.UPSProductNamespace + "-operator"
+		common.MonitoringSpecNamespace = common.NamespacePrefix + "monitoring"
+		common.Marin3rOperatorNamespace = common.NamespacePrefix + "marin3r-operator"
+		common.Marin3rProductNamespace = common.NamespacePrefix + "marin3r"
+		common.CustomerGrafanaNamespace = common.NamespacePrefix + "customer-monitoring-operator"
+
+		// get all automated tests
+		tests := []common.Tests{
+			{
+				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
+				TestCases: common.GetHappyPathTestCases(installType),
+			},
+			{
+				Type:      fmt.Sprintf("%s pre-test", installType),
+				TestCases: OSD_E2E_PRE_TESTS,
+			},
+		}
+
+		for _, test := range tests {
+			Context(test.Type, func() {
+				for _, testCase := range test.TestCases {
+					currentTest := testCase
+					It(currentTest.Description, func() {
+						testingContext, err := common.NewTestingContext(restConfig)
+						if err != nil {
+							t.Fatal("failed to create testing context", err)
+						}
+						currentTest.Test(t, testingContext)
+					})
+				}
+			})
+		}
+
+	}
+
+	RunTests()
+
+})

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -1,0 +1,149 @@
+package osde2e
+
+import (
+	"context"
+	goctx "context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	OSD_E2E_PRE_TESTS = []common.TestCase{
+		{Description: "Managed-API pre-test", Test: PreTest},
+	}
+	pagerDutySecretName = "pagerduty"
+	deadMansSnitchName  = "deadmanssnitch"
+	smtpSecretName      = "smtp"
+)
+
+//PreTest This tests if an installation of Managed-API was finished and is successful
+func PreTest(t common.TestingTB, ctx *common.TestingContext) {
+	err := wait.Poll(time.Second*15, time.Minute*40, func() (done bool, err error) {
+
+		rhmi, err := getRHMI(ctx.Client)
+		if err != nil {
+			t.Fatalf("error getting RHMI CR: %v", err)
+		}
+
+		// Patch Managed-API CR with cluster storage
+		if rhmi.Spec.UseClusterStorage == "false" || rhmi.Spec.UseClusterStorage == "" {
+			rhmiCR := fmt.Sprintf(`{
+				"apiVersion": "integreatly.org/v1alpha1",
+				"kind": "RHMI",
+				"spec": {
+					"useClusterStorage" : "true"
+				}
+			}`)
+
+			rhmiCRBytes := []byte(rhmiCR)
+
+			request := ctx.ExtensionClient.RESTClient().Patch(types.MergePatchType).
+				Resource("rhmis").
+				Name("rhoam").
+				Namespace(common.RHMIOperatorNamespace).
+				RequestURI("/apis/integreatly.org/v1alpha1").Body(rhmiCRBytes).Do(context.TODO())
+			_, err := request.Raw()
+
+			if err != nil {
+				return false, err
+			}
+		}
+
+		// Get smtp secret - if failed - create SMTP Secret
+		_, err = getSecret(ctx.Client, common.NamespacePrefix+smtpSecretName)
+		if err != nil {
+			smtpSec := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprint(common.NamespacePrefix + smtpSecretName),
+					Namespace: common.RHMIOperatorNamespace,
+				},
+				Data: map[string][]byte{
+					"host":     []byte("test"),
+					"password": []byte("test"),
+					"port":     []byte("test"),
+					"tls":      []byte("test"),
+					"username": []byte("test"),
+				},
+			}
+			if err := ctx.Client.Create(goctx.TODO(), smtpSec.DeepCopy()); err != nil {
+				t.Fatalf("Failed to create Pager Duty Secret: %v", err)
+			}
+		}
+
+		// Get pagerduty secret - if failed - create
+		_, err = getSecret(ctx.Client, common.NamespacePrefix+pagerDutySecretName)
+		if err != nil {
+
+			pagerDuty := v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NamespacePrefix + pagerDutySecretName,
+					Namespace: common.RHMIOperatorNamespace,
+				},
+				Data: map[string][]byte{
+					"serviceKey": []byte("test"),
+				},
+			}
+			if err := ctx.Client.Create(goctx.TODO(), pagerDuty.DeepCopy()); err != nil {
+				t.Fatalf("Failed to create Pager Duty Secret: %v", err)
+			}
+		}
+
+		// Get dms - if failed - create
+		_, err = getSecret(ctx.Client, common.NamespacePrefix+deadMansSnitchName)
+		if err != nil {
+
+			dms := v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NamespacePrefix + deadMansSnitchName,
+					Namespace: common.RHMIOperatorNamespace,
+				},
+				Data: map[string][]byte{
+					"url": []byte("test"),
+				},
+			}
+			if err := ctx.Client.Create(goctx.TODO(), dms.DeepCopy()); err != nil {
+				t.Fatalf("Failed to create DMS secret: %v", err)
+			}
+		}
+
+		if rhmi.Status.Stage != "complete" {
+			t.Logf("Current stage is %v", rhmi.Status.Stage)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		t.Errorf("Something went wrong ...%v", err)
+	}
+}
+
+func getRHMI(client dynclient.Client) (*integreatlyv1alpha1.RHMI, error) {
+	rhmi := &integreatlyv1alpha1.RHMI{}
+	watchNS := common.GetNamespacePrefix()
+	nsSegments := strings.Split(watchNS, "-")
+	crName := nsSegments[1]
+	if err := client.Get(goctx.TODO(), types.NamespacedName{Name: crName, Namespace: common.RHMIOperatorNamespace}, rhmi); err != nil {
+		return nil, fmt.Errorf("error getting RHMI CR: %w", err)
+	}
+	return rhmi, nil
+}
+
+func getSecret(client dynclient.Client, secretName string) (*v1.Secret, error) {
+	secret := &v1.Secret{}
+
+	if err := client.Get(goctx.TODO(), types.NamespacedName{Name: secretName, Namespace: common.RHMIOperatorNamespace}, secret); err != nil {
+		return nil, fmt.Errorf("Error getting secret")
+	}
+	return secret, nil
+}

--- a/test/osde2e/suite_test.go
+++ b/test/osde2e/suite_test.go
@@ -1,0 +1,88 @@
+package osde2e
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/common"
+)
+
+const (
+	testResultsDirectory = "/test-run-results"
+	jUnitOutputFilename  = "junit-integreatly-operator.xml"
+	addonMetadataName    = "addon-metadata.json"
+	testOutputFileName   = "test-output.txt"
+	testSuiteName        = "integreatly-operator"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var installType string
+var err error
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	// start test env
+	By("bootstrapping test environment")
+
+	useCluster := true
+	testEnv = &envtest.Environment{
+		UseExistingCluster:       &useCluster,
+		AttachControlPlaneOutput: true,
+	}
+	cfg, err = testEnv.Start()
+	if err != nil {
+		t.Fatalf("could not get start test environment %s", err)
+	}
+	//TODO: Trigger operator install
+
+	//TODO: validate operator has completed install
+
+	// get install type
+	installType, err = common.GetInstallType(cfg)
+	if err != nil {
+		t.Fatalf("could not get install type %s", err)
+	}
+
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s/%s", testResultsDirectory, jUnitOutputFilename))
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{junitReporter})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	err = rhmiv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	close(done)
+}, 120)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+
+	//TODO: remove operator
+
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/test/resources/3scale_api.go
+++ b/test/resources/3scale_api.go
@@ -1,0 +1,370 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	url2 "net/url"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ThreeScalePingUrl          = "%v/admin/api/applications.xml"
+	ThreeScaleProductCreateUrl = "%v/apiconfig/services"
+	ThreeScaleProductDeleteUrl = "%v/apiconfig/services/%v"
+	ThreeScaleClient           = "3scale"
+	ThreeScaleUserInviteUrl    = "%v/p/admin/account/invitations/"
+)
+
+type ThreeScaleAPIClient interface {
+	Ping() error
+	LoginOpenshift(masterUrl, username, password, namespacePrefix string) error
+	Login3Scale(clientSecret string) error
+	CreateProduct(name string) (string, error)
+	DeleteProduct(href string) error
+	SendUserInvitation(name string) (string, error)
+	SetUserAsAdmin(username string, email string, userID string) error
+	GetUserId(username string) (string, error)
+	VerifyUserIsAdmin(userID string) (bool, error)
+}
+
+type ThreeScaleAPIClientImpl struct {
+	host         string
+	client       *http.Client
+	kubeClient   k8sclient.Client
+	token        string
+	keycloakHost string
+	redirectUrl  string
+	logger       SimpleLogger
+}
+
+func NewThreeScaleAPIClient(host, keycloakHost, redirectUrl string, client *http.Client, kubeClient k8sclient.Client, logger SimpleLogger) ThreeScaleAPIClient {
+	return &ThreeScaleAPIClientImpl{
+		host:         host,
+		client:       client,
+		kubeClient:   kubeClient,
+		keycloakHost: keycloakHost,
+		redirectUrl:  redirectUrl,
+		logger:       logger,
+	}
+}
+
+// Request a csrf token to be used in a form post request by sending
+// a get request to the form url first
+func requestCRSFToken(c *http.Client, formUrl string) (string, error) {
+	resp, err := c.Get(formUrl)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	doc, err := ParseHtmlResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	selector := doc.Find("meta[name='csrf-token']")
+	if selector.Length() == 0 {
+		return "", errors.New(fmt.Sprintf("no csrf token found in: %v", doc.Text()))
+	}
+
+	// Get the csrf token from the form to use it in the post
+	csrf, _ := selector.Attr("content")
+	return csrf, nil
+}
+
+func (r *ThreeScaleAPIClientImpl) Login3Scale(clientSecret string) error {
+	token, err := Auth3Scale(r.client, r.redirectUrl, r.keycloakHost, ThreeScaleClient, clientSecret)
+	if err != nil {
+		return err
+	}
+
+	r.token = token
+	return nil
+}
+
+func (r *ThreeScaleAPIClientImpl) LoginOpenshift(masterUrl, username, password, namespacePrefix string) error {
+	authUrl := fmt.Sprintf("%s/auth/login", masterUrl)
+	if err := DoAuthOpenshiftUser(authUrl, username, password, r.client, "testing-idp", r.logger); err != nil {
+		return err
+	}
+
+	openshiftClient := NewOpenshiftClient(r.client, masterUrl)
+	if err := OpenshiftUserReconcileCheck(openshiftClient, r.kubeClient, namespacePrefix, username); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Call the applications endpoint of 3Scale to make sure it is available
+// and the user has permissions to retrieve the list of applications
+func (r *ThreeScaleAPIClientImpl) Ping() error {
+	url := fmt.Sprintf(ThreeScalePingUrl, r.host)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// Delete a 3Scale product by id
+func (r *ThreeScaleAPIClientImpl) DeleteProduct(id string) error {
+	url := fmt.Sprintf(ThreeScaleProductDeleteUrl, r.host, id)
+	formUrl := fmt.Sprintf("%v/apiconfig/services/%v/edit", r.host, id)
+
+	csrf, err := requestCRSFToken(r.client, formUrl)
+	if err != nil {
+		return err
+	}
+
+	formValues := url2.Values{
+		"authenticity_token": []string{csrf},
+		"_method":            []string{"delete"},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(formValues.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// Create a 3Scale product
+func (r *ThreeScaleAPIClientImpl) CreateProduct(name string) (string, error) {
+	url := fmt.Sprintf(ThreeScaleProductCreateUrl, r.host)
+	formUrl := fmt.Sprintf("%v/apiconfig/services/new", r.host)
+
+	// First try to get the CRSF token by requesting the form
+	csrf, err := requestCRSFToken(r.client, formUrl)
+	if err != nil {
+		return "", err
+	}
+
+	formValues := url2.Values{
+		"service[name]":        []string{name},
+		"service[system_name]": []string{fmt.Sprintf("%v-system", name)},
+		"service[description]": []string{fmt.Sprintf("%v dummy service", name)},
+		"commit":               []string{"Create+Product"},
+		"authenticity_token":   []string{csrf},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(formValues.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	// Parse the html to get a link back to the created service
+	doc, err := ParseHtmlResponse(resp)
+	selector := doc.Find("a.pf-c-nav__link")
+	if selector.Length() == 0 {
+		return "", errors.New("unable to retrieve service id")
+	}
+
+	href, _ := selector.Attr("href")
+	if strings.Contains(href, "/") == false {
+
+	}
+
+	id := strings.Split(href, "/")
+	return id[len(id)-1], nil
+}
+
+// Create a 3Scale user invite
+func (r *ThreeScaleAPIClientImpl) SendUserInvitation(name string) (string, error) {
+
+	url := fmt.Sprintf(ThreeScaleUserInviteUrl, r.host)
+	formUrl := fmt.Sprintf("%v/p/admin/account/invitations/new", r.host)
+
+	// First try to get the CRSF token by requesting the form
+	csrf, err := requestCRSFToken(r.client, formUrl)
+	if err != nil {
+		return "", err
+	}
+
+	formValues := url2.Values{
+		"invitation[email]": []string{name},
+		//"service[system_name]": []string{fmt.Sprintf("%v-system", name)},
+		//"service[description]": []string{fmt.Sprintf("%v dummy service", name)},
+		"commit":             []string{"Send"},
+		"authenticity_token": []string{csrf},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(formValues.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	return "Completed", nil
+}
+
+func (r *ThreeScaleAPIClientImpl) SetUserAsAdmin(username string, email string, userID string) error {
+
+	url := fmt.Sprintf("%v/p/admin/account/users/%v", r.host, userID)
+	formUrl := fmt.Sprintf("%v/p/admin/account/users/%v/edit", r.host, userID)
+
+	// First try to get the CRSF token by requesting the form
+	csrf, err := requestCRSFToken(r.client, formUrl)
+	if err != nil {
+		return err
+	}
+
+	formValues := url2.Values{
+		"user[username]":              []string{username},
+		"user[email]":                 []string{email},
+		"user[role]":                  []string{"admin"},
+		"user[password]":              []string{},
+		"user[password_confirmation]": []string{},
+		"commit":                      []string{"Update+User"},
+		"authenticity_token":          []string{csrf},
+		"_method":                     []string{"patch"},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(formValues.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+func (r *ThreeScaleAPIClientImpl) GetUserId(username string) (string, error) {
+	url := fmt.Sprintf("%v/p/admin/account/users", r.host)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", r.token))
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("expected 200 but got %v", resp.StatusCode))
+	}
+
+	doc, err := ParseHtmlResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	links := doc.Find("a[title='Edit']")
+
+	link := ""
+	links.Each(func(index int, s *goquery.Selection) {
+		if s.Contents().Text() == username {
+			link, _ = s.Attr("href")
+			return
+		}
+	})
+
+	if link == "" {
+		return "", fmt.Errorf("Failed to retrieve link to edit user")
+	}
+
+	userId := ""
+	s := strings.Split(link, "/")
+	for _, val := range s {
+		if _, err := strconv.Atoi(val); err == nil {
+			userId = val
+			break
+		}
+	}
+
+	return userId, nil
+}
+
+func (r *ThreeScaleAPIClientImpl) VerifyUserIsAdmin(userID string) (bool, error) {
+
+	formUrl := fmt.Sprintf("%v/p/admin/account/users/%v/edit", r.host, userID)
+	resp, err := r.client.Get(formUrl)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	doc, err := ParseHtmlResponse(resp)
+	if err != nil {
+		return false, err
+	}
+
+	selector := doc.Find("input[id='user_role_admin']")
+	_, exists := selector.Attr("checked")
+	if exists {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/test/resources/apicurio_registry_api.go
+++ b/test/resources/apicurio_registry_api.go
@@ -1,0 +1,109 @@
+package resources
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	Avro ArtifactType = "AVRO"
+)
+
+type ArtifactType string
+
+type ApicurioRegistryApiClient interface {
+	CreateArtifact(id string, artifactType ArtifactType, data string) error
+	ReadArtifact(id string) (string, error)
+	DeleteArtifact(id string) error
+}
+
+type ApicurioRegistryApiClientImpl struct {
+	host       string
+	httpClient *http.Client
+}
+
+func NewApicurioRegistryApiClient(host string, httpClient *http.Client) ApicurioRegistryApiClient {
+	return &ApicurioRegistryApiClientImpl{
+		host:       host,
+		httpClient: httpClient,
+	}
+}
+
+func (r *ApicurioRegistryApiClientImpl) CreateArtifact(id string, artifactType ArtifactType, data string) error {
+	url := fmt.Sprintf("http://%v/api/artifacts", r.host)
+	body := bytes.NewBuffer([]byte(data))
+
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return err
+	}
+
+	switch artifactType {
+	case Avro:
+		req.Header.Set("Content-Type", fmt.Sprintf("application/json; artifactType=%v", Avro))
+	}
+
+	req.Header.Set("X-Registry-ArtifactId", id)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(fmt.Sprintf("expected status 200 but received %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+func (r *ApicurioRegistryApiClientImpl) ReadArtifact(id string) (string, error) {
+	url := fmt.Sprintf("http://%v/api/artifacts/%v", r.host, id)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf(fmt.Sprintf("expected status 200 but received %v", resp.StatusCode))
+	}
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	data := string(bytes)
+
+	return data, nil
+}
+
+func (r *ApicurioRegistryApiClientImpl) DeleteArtifact(id string) error {
+	url := fmt.Sprintf("http://%v/api/artifacts/%v", r.host, id)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf(fmt.Sprintf("expected status %v but received %v", http.StatusNoContent, resp.StatusCode))
+	}
+
+	return nil
+}

--- a/test/resources/codeready_api.go
+++ b/test/resources/codeready_api.go
@@ -1,0 +1,189 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	pingUrl             = "%v/dashboard/"
+	createWorkspacePath = "%v/api/workspace/devfile"
+	getWorkspacePath    = "%v/api/workspace/%v"
+	stopWorkspacePath   = "%v/api/workspace/%v/runtime"
+	deleteWorkspacePath = "%v/api/workspace/%v"
+)
+
+type CodereadyApiResult struct {
+	ID     string `json:"id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type CodereadyApiClient interface {
+	Ping() error
+	GetWorkspace() (*CodereadyApiResult, error)
+	CreateWorkspace() (string, error)
+	StopWorkspace() error
+	DeleteWorkspace() error
+}
+
+type CodereadyApiClientImpl struct {
+	host        string
+	httpClient  *http.Client
+	accessToken string
+}
+
+func NewCodereadyApiClient(httpClient *http.Client, host string, accessToken string) *CodereadyApiClientImpl {
+	return &CodereadyApiClientImpl{
+		host:        host,
+		httpClient:  httpClient,
+		accessToken: accessToken,
+	}
+}
+
+func (c *CodereadyApiClientImpl) Ping() error {
+	url := fmt.Sprintf(pingUrl, c.host)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.accessToken))
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected response status %v but got %v", http.StatusOK, res.StatusCode)
+	}
+
+	return nil
+}
+
+/*
+Sends a request to /api/workspace/devfile endpoint to create a workspace and starts it as soon as it is created.
+Returns the workspace ID upon successful workspace creation, otherwise it returns an error.
+*/
+func (c *CodereadyApiClientImpl) CreateWorkspace(devfile []byte) (string, error) {
+	url := fmt.Sprintf(createWorkspacePath, c.host)
+	url = fmt.Sprintf("%s?start-after-create=true", url)
+
+	payload := bytes.NewBufferString(string(devfile))
+
+	req, err := http.NewRequest(http.MethodPost, url, payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to create a new request: %v", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.accessToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %v", err)
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected response status %v but got %v: %v", http.StatusCreated, res.StatusCode, string(data))
+	}
+
+	result := &CodereadyApiResult{}
+	if err := json.Unmarshal(data, result); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response %v: %v", err, string(data))
+	}
+
+	return result.ID, nil
+}
+
+// Gets a workspace by id
+func (c *CodereadyApiClientImpl) GetWorkspace(id string) (*CodereadyApiResult, error) {
+	url := fmt.Sprintf(getWorkspacePath, c.host, id)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.accessToken))
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected response status %v but got %v: %v", http.StatusOK, res.StatusCode, string(data))
+	}
+
+	result := &CodereadyApiResult{}
+	if err := json.Unmarshal(data, result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	return result, nil
+}
+
+// Stops a workspace specified by id
+func (c *CodereadyApiClientImpl) StopWorkspace(id string) error {
+	url := fmt.Sprintf(stopWorkspacePath, c.host, id)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.accessToken))
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		data, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %v", err)
+		}
+		return fmt.Errorf("expected response status %v but got %v: %v", http.StatusNoContent, res.StatusCode, string(data))
+	}
+
+	return nil
+}
+
+// Deletes a workspace specified by id
+func (c *CodereadyApiClientImpl) DeleteWorkspace(id string) error {
+	url := fmt.Sprintf(deleteWorkspacePath, c.host, id)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.accessToken))
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		data, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %v", err)
+		}
+		return fmt.Errorf("expected response status %v but got %v: %v", http.StatusNoContent, res.StatusCode, string(data))
+	}
+
+	return nil
+}

--- a/test/resources/codeready_login.go
+++ b/test/resources/codeready_login.go
@@ -1,0 +1,154 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	codereadySSOAuthEndpoint  = "%v/auth/realms/openshift/protocol/openid-connect/auth?client_id=%v&redirect_uri=%v&response_type=code&scope=openid"
+	codereadySSOTokenEndpoint = "%v/auth/realms/openshift/protocol/openid-connect/token"
+	clientId                  = "che-client"
+)
+
+type CodereadyLoginClient struct {
+	HttpClient *http.Client
+	Client     k8sclient.Client
+	MasterUrl  string
+	IdpName    string
+	Username   string
+	Password   string
+	Logger     SimpleLogger
+}
+
+func NewCodereadyLoginClient(httpClient *http.Client, client k8sclient.Client, masterUrl, idp, username, password string, logger SimpleLogger) *CodereadyLoginClient {
+	return &CodereadyLoginClient{
+		HttpClient: httpClient,
+		Client:     client,
+		MasterUrl:  masterUrl,
+		IdpName:    idp,
+		Username:   username,
+		Password:   password,
+		Logger:     logger,
+	}
+}
+
+// Login user to openshift and wait for the user to be reconciled to the openshift realm in keycloak
+func (c *CodereadyLoginClient) OpenshiftLogin(namespacePrefix string) error {
+	authUrl := fmt.Sprintf("%s/auth/login", c.MasterUrl)
+	if err := DoAuthOpenshiftUser(authUrl, c.Username, c.Password, c.HttpClient, c.IdpName, c.Logger); err != nil {
+		return err
+	}
+
+	openshiftClient := NewOpenshiftClient(c.HttpClient, c.MasterUrl)
+	if err := OpenshiftUserReconcileCheck(openshiftClient, c.Client, namespacePrefix, c.Username); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Log user into codeready. Returns an access token to be used for codeready API calls
+func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string) (string, error) {
+	u := fmt.Sprintf(codereadySSOAuthEndpoint, keycloakHost, clientId, redirectUrl)
+
+	response, err := c.HttpClient.Get(u)
+	if err != nil {
+		return "", fmt.Errorf("failed to get %v: %v", u, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	// Select the testing IDP
+	document, err := parseResponse(response)
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	// find the link to the testing IDP
+	link, err := findElement(document, fmt.Sprintf("a:contains('%s')", c.IdpName))
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	// get the url from the
+	href, err := getAttribute(link, "href")
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	u, err = resolveRelativeURL(response, href)
+	if err != nil {
+		return "", err
+	}
+	response, err = c.HttpClient.Get(u)
+	if err != nil {
+		return "", fmt.Errorf("failed to get %v: %v", u, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+	// t.Logf("Response: raw query = %s", response.Request.URL.RawQuery)
+	code := strings.Split(response.Request.URL.RawQuery, "&")[1]
+	tokenUrl := fmt.Sprintf(codereadySSOTokenEndpoint, keycloakHost)
+	// t.Logf("Received code: %s", code)
+	// t.Logf("Token url: %s", tokenUrl)
+
+	formValues := url.Values{
+		"grant_type":   []string{"authorization_code"},
+		"code":         []string{strings.Split(code, "=")[1]},
+		"client_id":    []string{clientId},
+		"redirect_uri": []string{redirectUrl},
+	}
+
+	response, err = c.HttpClient.PostForm(tokenUrl, formValues)
+	if err != nil {
+		return "", fmt.Errorf("failed to request %s: %s", tokenUrl, err)
+	}
+
+	postBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+
+	tokenResponse := struct {
+		AccessToken string `json:"access_token"`
+	}{}
+
+	json.Unmarshal(postBody, &tokenResponse)
+
+	if tokenResponse.AccessToken == "" {
+		return "", fmt.Errorf("failed to get access token: %v", string(postBody))
+	}
+	return tokenResponse.AccessToken, nil
+}
+
+func parseResponse(r *http.Response) (*goquery.Document, error) {
+	// Clone the body while reading it so that in case of errors
+	// we can dump the response with the body
+	var clone bytes.Buffer
+	body := io.TeeReader(r.Body, &clone)
+	r.Body = ioutil.NopCloser(&clone)
+
+	d, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the document: %s", err)
+	}
+
+	// <noscript> bug workaround
+	// https://github.com/PuerkitoBio/goquery/issues/139#issuecomment-517526070
+	d.Find("noscript").Each(func(i int, s *goquery.Selection) {
+		s.SetHtml(s.Text())
+	})
+
+	return d, nil
+}

--- a/test/resources/fuse_api.go
+++ b/test/resources/fuse_api.go
@@ -1,0 +1,156 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	testingIDP                  = "testing-idp"
+	fuseApiPingUrl              = "%v/api/v1/public/environments"
+	fuseApiIntegrationsUrl      = "%v/api/v1/integrations"
+	fuseApiDeleteIntegrationUrl = "%v/api/v1/integrations/%v"
+)
+
+type FuseApiClient interface {
+	Ping() error
+	CountIntegrations() (int, error)
+	CreateIntegration(schema string) (string, error)
+	DeleteIntegration(id string) error
+}
+
+type FuseApiClientImpl struct {
+	host   string
+	client *http.Client
+}
+
+func NewFuseApiClient(host string, client *http.Client) FuseApiClient {
+	return &FuseApiClientImpl{
+		host:   host,
+		client: client,
+	}
+}
+
+// Check fuse connectivity by calling a public endpoint
+func (r *FuseApiClientImpl) Ping() error {
+	url := fmt.Sprintf(fuseApiPingUrl, r.host)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(fmt.Sprintf("fuse ping: expected status 200 but got %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// Creates a simple integration using timer and logger
+func (r *FuseApiClientImpl) CreateIntegration(schema string) (string, error) {
+	url := fmt.Sprintf(fuseApiIntegrationsUrl, r.host)
+
+	payload := bytes.NewBuffer([]byte(schema))
+	req, err := http.NewRequest(http.MethodPost, url, payload)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// The fuse API expects this, otherwise a 403 is returned because of a missing
+	// csrf token
+	req.Header.Set("SYNDESIS-XSRF-TOKEN", "awesome")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	apiResult := struct {
+		ID string `json:"id"`
+	}{}
+
+	err = json.Unmarshal(data, &apiResult)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("error creating fuse integration, expected status 201 but received %v", resp.StatusCode))
+	}
+
+	return apiResult.ID, nil
+}
+
+// Deletes an integration by id
+func (r *FuseApiClientImpl) DeleteIntegration(id string) error {
+	url := fmt.Sprintf(fuseApiDeleteIntegrationUrl, r.host, id)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	// The fuse API expects this, otherwise a 403 is returned because of a missing
+	// csrf token
+	req.Header.Set("SYNDESIS-XSRF-TOKEN", "awesome")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.New(fmt.Sprintf("error deleting fuse integration, expected status 204 but received %v", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// Returns the number of existing integrations
+func (r *FuseApiClientImpl) CountIntegrations() (int, error) {
+	url := fmt.Sprintf(fuseApiIntegrationsUrl, r.host)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, errors.New(fmt.Sprintf("fuse api: expected status 200 but got %v", resp.StatusCode))
+	}
+
+	apiResult := struct {
+		TotalCount int `json:"totalCount"`
+	}{}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	err = json.Unmarshal(data, &apiResult)
+	if err != nil {
+		return 0, err
+	}
+
+	return apiResult.TotalCount, nil
+}

--- a/test/resources/fuse_payload.go
+++ b/test/resources/fuse_payload.go
@@ -1,0 +1,200 @@
+package resources
+
+// The payload for a simple fuse integration based on timer and logger
+const FuseIntegrationPayload = `
+{
+  "name": "test-integration",
+  "tags": [
+    "timer"
+  ],
+  "flows": [
+    {
+      "id": "-M30tHvcORdr7SjkRAjn",
+      "name": "",
+      "steps": [
+        {
+          "id": "-M30tMT1ORdr7SjkRAjn",
+          "configuredProperties": {
+            "period": "60000"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "action": {
+            "id": "io.syndesis:timer-action",
+            "name": "Simple",
+            "description": "Specify an amount of time and its unit to periodically trigger integration execution. ",
+            "descriptor": {
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "none"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "name": "Period",
+                  "properties": {
+                    "period": {
+                      "componentProperty": false,
+                      "defaultValue": "60000",
+                      "deprecated": false,
+                      "description": "Period",
+                      "displayName": "Period",
+                      "javaType": "long",
+                      "kind": "parameter",
+                      "labelHint": "Delay between each execution of the integration.",
+                      "required": true,
+                      "secret": false,
+                      "type": "duration"
+                    }
+                  },
+                  "description": "Period"
+                }
+              ],
+              "configuredProperties": {
+                "timerName": "syndesis-timer"
+              },
+              "componentScheme": "timer"
+            },
+            "actionType": "connector",
+            "pattern": "From"
+          },
+          "connection": {
+            "uses": 0,
+            "id": "timer",
+            "name": "Timer",
+            "metadata": {
+              "hide-from-connection-pages": "true"
+            },
+            "connector": {
+              "id": "timer",
+              "version": 4,
+              "actions": [
+                {
+                  "id": "io.syndesis:timer-action",
+                  "name": "Simple",
+                  "description": "Specify an amount of time and its unit to periodically trigger integration execution. ",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "Period",
+                        "properties": {
+                          "period": {
+                            "componentProperty": false,
+                            "defaultValue": "60000",
+                            "deprecated": false,
+                            "description": "Period",
+                            "displayName": "Period",
+                            "javaType": "long",
+                            "kind": "parameter",
+                            "labelHint": "Delay between each execution of the integration.",
+                            "required": true,
+                            "secret": false,
+                            "type": "duration"
+                          }
+                        },
+                        "description": "Period"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "timerName": "syndesis-timer"
+                    },
+                    "componentScheme": "timer"
+                  },
+                  "actionType": "connector",
+                  "pattern": "From"
+                },
+                {
+                  "id": "io.syndesis:timer-chron",
+                  "name": "Cron",
+                  "description": "Specify a cron utility expression for a more complex integration execution schedule.",
+                  "descriptor": {
+                    "inputDataShape": {
+                      "kind": "none"
+                    },
+                    "outputDataShape": {
+                      "kind": "none"
+                    },
+                    "propertyDefinitionSteps": [
+                      {
+                        "name": "cron",
+                        "properties": {
+                          "cron": {
+                            "componentProperty": false,
+                            "defaultValue": "0 0/1 * * * ?",
+                            "deprecated": false,
+                            "description": "A cron expression, for example the expression for every minute is 0 0/1 * * * ?",
+                            "displayName": "Cron Expression",
+                            "javaType": "string",
+                            "kind": "parameter",
+                            "labelHint": "Delay between scheduling (executing) the integration expressed as a cron expression",
+                            "required": true,
+                            "secret": false,
+                            "type": "string"
+                          }
+                        },
+                        "description": "Cron"
+                      }
+                    ],
+                    "configuredProperties": {
+                      "triggerName": "syndesis-quartz"
+                    },
+                    "componentScheme": "quartz2"
+                  },
+                  "actionType": "connector",
+                  "pattern": "From"
+                }
+              ],
+              "name": "Timer",
+              "dependencies": [
+                {
+                  "type": "MAVEN",
+                  "id": "io.syndesis.connector:connector-timer:1.8.6.fuse-750001-redhat-00002"
+                },
+                {
+                  "type": "MAVEN",
+                  "id": "org.apache.camel:camel-quartz2:2.21.0.fuse-750033-redhat-00001"
+                }
+              ],
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "description": "Trigger events based on an interval or a quartz expression",
+              "icon": "assets:timer.svg"
+            },
+            "connectorId": "timer",
+            "icon": "assets:timer.svg",
+            "description": "Trigger integration execution based on an interval or a cron expression",
+            "isDerived": false
+          },
+          "stepKind": "endpoint"
+        },
+        {
+          "id": "-M30tNPcORdr7SjkRAjn",
+          "configuredProperties": {
+            "contextLoggingEnabled": "false",
+            "bodyLoggingEnabled": "false"
+          },
+          "metadata": {
+            "configured": "true"
+          },
+          "stepKind": "log",
+          "name": "Log"
+        }
+      ],
+      "tags": [
+        "timer"
+      ],
+      "type": "PRIMARY"
+    }
+  ],
+  "description": ""
+}
+`

--- a/test/resources/oauth_proxy_auth.go
+++ b/test/resources/oauth_proxy_auth.go
@@ -1,0 +1,368 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+)
+
+func Auth3Scale(client *http.Client, redirectUrl, keycloakHost, clientId, secret string) (string, error) {
+	// Start the authentication
+	u := fmt.Sprintf("%v/auth/realms/openshift/protocol/openid-connect/auth?client_id=%v&redirect_uri=%v&response_type=code&scope=openid", keycloakHost, clientId, redirectUrl)
+	response, err := client.Get(u)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	// Select the testing IDP
+	document, err := ParseHtmlResponse(response)
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	// find the link to the testing IDP
+	link, err := findElement(document, fmt.Sprintf("a:contains('%s')", testingIDP))
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	// get the url from the link
+	href, err := getAttribute(link, "href")
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	u, err = resolveRelativeURL(response, href)
+	if err != nil {
+		return "", err
+	}
+
+	response, err = client.Get(u)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to request %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	document, err = ParseHtmlResponse(response)
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	// 3scale auth page, select the keycloak auth option
+	link, err = findElement(document, "a.authorizeLink")
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+	href, err = getAttribute(link, "href")
+	if err != nil {
+		return "", errorWithResponseDump(response, err)
+	}
+
+	response, err = client.Get(href)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	code := strings.Split(response.Request.URL.RawQuery, "&")[1]
+	tokenUrl := fmt.Sprintf("%v/auth/realms/openshift/protocol/openid-connect/token", keycloakHost)
+	formValues := url.Values{
+		"grant_type":    []string{"authorization_code"},
+		"code":          []string{strings.Split(code, "=")[1]},
+		"client_id":     []string{"3scale"},
+		"redirect_uri":  []string{redirectUrl},
+		"client_secret": []string{secret},
+	}
+
+	response, err = client.PostForm(tokenUrl, formValues)
+	if err != nil {
+		return "", fmt.Errorf("failed to request %s: %s", u, err)
+	}
+
+	// extract the token
+	postBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+
+	tokenResponse := struct {
+		AccessToken string `json:"access_token"`
+	}{}
+
+	json.Unmarshal(postBody, &tokenResponse)
+	return tokenResponse.AccessToken, nil
+}
+
+// Login a user through the oauth proxy
+func ProxyOAuth(client *http.Client, host string, username string, password string) (*http.Client, error) {
+
+	// Start the authentication
+	u := fmt.Sprintf("%s/oauth/start", host)
+	response, err := client.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return nil, errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	// Select the testing IDP
+	document, err := ParseHtmlResponse(response)
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	// find the link to the testing IDP
+	link, err := findElement(document, fmt.Sprintf("a:contains('%s')", testingIDP))
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	// get the url from the
+	href, err := getAttribute(link, "href")
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	u, err = resolveRelativeURL(response, href)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err = client.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return nil, errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	// Submit the username and password
+	document, err = ParseHtmlResponse(response)
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	// find the form for the login
+	form, err := findElement(document, "#kc-form-login")
+	if err != nil {
+		// maybe wer are already logged in (previous openshift login)
+		// find the form for the approval
+		form = document.Find("form")
+		if form.Length() == 0 {
+			// Nope
+			// return nil, errorWithResponseDump(response, err)
+			// this is a workaround for the oauth-proxy issue (https://issues.redhat.com/browse/INTLY-8473)
+			return client, nil
+		}
+
+		_, err = approvePermissions(form, client, response)
+		if err != nil {
+			return nil, errorWithResponseDump(response, err)
+		}
+
+		return client, nil
+	}
+
+	// retrieve the action of the form
+	action, err := getAttribute(form, "action")
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	u, err = resolveRelativeURL(response, action)
+	if err != nil {
+		return nil, err
+	}
+
+	// submit the form with the username and password
+	v := url.Values{"username": []string{username}, "password": []string{password}}
+	response, err = client.PostForm(u, v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request %s: %s", u, err)
+	}
+	if response.StatusCode != 200 {
+		return nil, errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
+	}
+
+	document, err = ParseHtmlResponse(response)
+	if err != nil {
+		return nil, err
+	}
+
+	// find the form for the approval
+	form = document.Find("form")
+	if err != nil {
+		return nil, errorWithResponseDump(response, err)
+	}
+
+	// No form found: no further approval required, we are authenticated
+	// at this point
+	if form.Length() == 0 {
+		return client, nil
+	}
+
+	// On first login the user is presented with an approval form. We have to submit
+	// the form along with the scopes that we want to grant.
+	_, err = approvePermissions(form, client, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func verifyRedirect(redirectUrl, host string) error {
+	if redirectUrl != host {
+		return errors.New(fmt.Sprintf("redirect host does not match product host: %v / %v",
+			redirectUrl,
+			host))
+	}
+	return nil
+}
+
+// Submit permission approval form
+func approvePermissions(form *goquery.Selection, client *http.Client, response *http.Response) (string, error) {
+	// retrieve the action of the form
+	action, err := getAttribute(form, "action")
+	if err != nil {
+		return "", err
+	}
+
+	// form submit url
+	formUrl, err := resolveRelativeURL(response, action)
+	if err != nil {
+		return "", err
+	}
+
+	then, _ := form.Find("input[name='then']").Attr("value")
+	csrf, _ := form.Find("input[name='csrf']").Attr("value")
+	clientId, _ := form.Find("input[name='client_id']").Attr("value")
+	userName, _ := form.Find("input[name='user_name']").Attr("value")
+	redirectUrl, _ := form.Find("input[name='redirect_uri']").Attr("value")
+
+	_, err = client.PostForm(formUrl, url.Values{
+		"then":         []string{then},
+		"csrf":         []string{csrf},
+		"client_id":    []string{clientId},
+		"user_name":    []string{userName},
+		"redirect_uri": []string{redirectUrl},
+		"scope":        []string{"user:info", "user:check-access"},
+		"approve":      []string{"Allow+selected+permissions"},
+	})
+	return redirectUrl, err
+}
+
+func dumpResponse(r *http.Response) string {
+	msg := "> Request\n"
+	reqOut, err := httputil.DumpRequestOut(r.Request, false)
+	if err != nil {
+		msg += fmt.Sprintf("failed to dump the request: %s", err)
+	} else {
+		msg += string(reqOut)
+	}
+	msg += "\n"
+
+	msg += "< Response\n"
+	for name, values := range r.Header {
+		// Loop over all values for the name.
+		for _, value := range values {
+			msg += name + " " + value + "\n"
+		}
+	}
+
+	document, err := ParseHtmlResponse(r)
+	if err != nil {
+		msg += "parse html response failed"
+	} else {
+		selection := document.Find("body")
+		if selection.Length() == 1 {
+			var b bytes.Buffer
+			err = html.Render(&b, selection.Nodes[0])
+			msg += b.String()
+		}
+	}
+
+	msg += "\n"
+
+	return msg
+}
+
+func errorWithResponseDump(r *http.Response, err error) error {
+	return fmt.Errorf("%s\n\n%s", err, dumpResponse(r))
+}
+
+func ParseHtmlResponse(r *http.Response) (*goquery.Document, error) {
+	// Clone the body while reading it so that in case of errors
+	// we can dump the response with the body
+	var clone bytes.Buffer
+	body := io.TeeReader(r.Body, &clone)
+	r.Body = ioutil.NopCloser(&clone)
+
+	d, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the document: %s", err)
+	}
+
+	// <noscript> bug workaround
+	// https://github.com/PuerkitoBio/goquery/issues/139#issuecomment-517526070
+	d.Find("noscript").Each(func(i int, s *goquery.Selection) {
+		s.SetHtml(s.Text())
+	})
+
+	return d, nil
+}
+
+func resolveRelativeURL(r *http.Response, relativeURL string) (string, error) {
+	u, err := url.Parse(relativeURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the url %s: %s", relativeURL, err)
+	}
+
+	u = r.Request.URL.ResolveReference(u)
+
+	return u.String(), nil
+}
+
+func findElement(d *goquery.Document, selector string) (*goquery.Selection, error) {
+	e := d.Find(selector)
+	if e.Length() == 0 {
+		return nil, fmt.Errorf("failed to find an element matching the selector %s", selector)
+	}
+	if e.Length() > 1 {
+		return nil, fmt.Errorf("multiple element founded matching the selector %s", selector)
+	}
+
+	return e, nil
+}
+
+func getAttribute(element *goquery.Selection, name string) (string, error) {
+	v, ok := element.Attr(name)
+	if !ok {
+		e, err := element.Html()
+		if err != nil {
+			e = fmt.Sprintf("failed to get the html content: %s", err)
+		}
+
+		return "", fmt.Errorf("the element '%s' doesn't have the %s attribute", e, name)
+	}
+	return v, nil
+}

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -1,0 +1,267 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	projectv1 "github.com/openshift/api/project/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	OpenshiftPathListProjects     = "/api/kubernetes/apis/project.openshift.io/v1/projects"
+	OpenshiftPathGetProject       = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
+	OpenshiftPathListPods         = "/api/kubernetes/api/v1/namespaces/%v/pods"
+	OpenshiftPathGetSecret        = "/api/kubernetes/api/v1/namespaces/%s/secrets"
+	PathListRHMIConfig            = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs"
+	PathGetRHMIConfig             = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs/%s"
+	PathGetRoute                  = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
+	PathListStandardInfraConfig   = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs"
+	PathGetStandardInfraConfig    = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
+	PathListBrokeredInfraConfig   = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs"
+	PathGetBrokeredInfraConfig    = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
+	PathListAddressSpacePlan      = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans"
+	PathGetAddressSpacePlan       = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans/%s"
+	PathListAddressPlan           = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans"
+	PathGetAddressPlan            = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans/%s"
+	PathListAuthenticationService = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/authenticationservices"
+	PathGetAuthenticationService  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/authenticationservices/%s"
+)
+
+type OpenshiftClient struct {
+	HTTPClient *http.Client
+	MasterUrl  string
+	ApiUrl     string
+}
+
+func NewOpenshiftClient(httpClient *http.Client, masterUrl string) *OpenshiftClient {
+	openshiftAPIURL := strings.Replace(masterUrl, "console-openshift-console.apps.", "api.", 1) + ":6443"
+
+	return &OpenshiftClient{
+		MasterUrl:  masterUrl,
+		HTTPClient: httpClient,
+		ApiUrl:     openshiftAPIURL,
+	}
+}
+
+// returns all pods in a namesapce
+func (oc *OpenshiftClient) ListPods(projectName string) (*corev1.PodList, error) {
+	path := fmt.Sprintf(OpenshiftPathListPods, projectName)
+	resp, err := oc.GetRequest(path)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred performing oc get request : %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	foundPods := &corev1.PodList{}
+	if err = json.Unmarshal(respBody, &foundPods); err != nil {
+		return nil, fmt.Errorf("error occurred while unmarshalling pod list: %w", err)
+	}
+
+	return foundPods, nil
+}
+
+// returns a project
+func (oc *OpenshiftClient) GetProject(projectName string) (*projectv1.Project, error) {
+	path := fmt.Sprintf(OpenshiftPathGetProject, projectName)
+	resp, err := oc.GetRequest(path)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred performing oc get request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("expected status %v but got %v: forbidden to access %v project", http.StatusOK, resp.StatusCode, projectName)
+		}
+		return nil, fmt.Errorf("expected status %v but got %v", http.StatusOK, resp.StatusCode)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	project := &projectv1.Project{}
+	if err := json.Unmarshal(respBody, project); err != nil {
+		return nil, fmt.Errorf("error occurred while unmarshalling project: %v", err)
+	}
+
+	return project, nil
+}
+
+// returns all projects
+func (oc *OpenshiftClient) ListProjects() (*projectv1.ProjectList, error) {
+	resp, err := oc.GetRequest(OpenshiftPathListProjects)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred performing oc get request : %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	foundProjects := &projectv1.ProjectList{}
+	if err = json.Unmarshal(respBody, &foundProjects); err != nil {
+		return nil, fmt.Errorf("error occured while unmarshalling project list: %w", err)
+	}
+
+	return foundProjects, nil
+}
+
+// makes a get request to the specified openshift api endpoint
+func (oc *OpenshiftClient) GetRequest(path string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", oc.MasterUrl, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
+	}
+	resp, err := oc.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
+	}
+	return resp, nil
+}
+
+func (oc *OpenshiftClient) DoOpenshiftCreateProject(projectCR *projectv1.ProjectRequest) error {
+
+	projectJson, err := json.Marshal(projectCR)
+	if err != nil {
+		return fmt.Errorf("failed to marshal projectCR: %w", err)
+	}
+
+	response, err := oc.DoOpenshiftPostRequest(PathProjectRequests, projectJson)
+	if err != nil {
+		return fmt.Errorf("error occured durning oc request : %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated {
+		return fmt.Errorf("request to %s failed with code %d", PathProjectRequests, response.StatusCode)
+	}
+
+	return nil
+}
+
+func (oc *OpenshiftClient) DoOpenshiftCreateServiceInANamespace(namespace string, serviceCR *corev1.Service) error {
+	path := fmt.Sprintf("/api/v1/namespaces/%s/services", namespace)
+	serviceJSON, err := json.Marshal(serviceCR)
+	if err != nil {
+		return fmt.Errorf("failed to marshal serviceCR: %w", err)
+	}
+
+	response, err := oc.DoOpenshiftPostRequest(path, serviceJSON)
+	if err != nil {
+		return fmt.Errorf("error occured durning oc request : %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated {
+		return fmt.Errorf("request to %s failed with code %d", path, response.StatusCode)
+	}
+
+	return nil
+}
+
+func (oc *OpenshiftClient) DoOpenshiftCreatePodInANamespace(namespace string, podCR *corev1.Pod) error {
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods", namespace)
+	podJSON, err := json.Marshal(podCR)
+	if err != nil {
+		return fmt.Errorf("failed to marshal serviceCR: %w", err)
+	}
+
+	response, err := oc.DoOpenshiftPostRequest(path, podJSON)
+	if err != nil {
+		return fmt.Errorf("error occured durning oc request : %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated {
+		return fmt.Errorf("request to %s failed with code %d", path, response.StatusCode)
+	}
+	return nil
+}
+
+// makes a get request, expects a path
+func (oc *OpenshiftClient) DoOpenshiftGetRequest(path string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
+	}
+
+	return oc.PerformRequest(req)
+}
+
+// get Oauth token from cookie
+func getOauthTokenFromCookie(masterURL string, client *http.Client) (string, error) {
+	clusterURL, err := url.Parse(fmt.Sprintf("https://%s/api/", masterURL))
+	if err != nil {
+		return "", fmt.Errorf("unable to parse the url: %w", err)
+	}
+
+	var token string = ""
+	for _, cookie := range client.Jar.Cookies(clusterURL) {
+		if cookie.Name == "openshift-session-token" {
+			token = cookie.Value
+			break
+		}
+	}
+
+	if token == "" {
+		return "", fmt.Errorf("token not found: %w", err)
+	}
+
+	return token, nil
+}
+
+// makes a post request, expects a path and the body
+func (oc *OpenshiftClient) DoOpenshiftPostRequest(path string, data []byte) (*http.Response, error) {
+	requestUrl := fmt.Sprintf("https://%s%s", oc.ApiUrl, path)
+	req, err := http.NewRequest(http.MethodPost, requestUrl, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("Error reading request: %w", err)
+	}
+
+	return oc.PerformRequest(req)
+}
+
+// makes a put request, expects a path and the body
+func (oc *OpenshiftClient) DoOpenshiftPutRequest(path string, data []byte) (*http.Response, error) {
+	requestUrl := fmt.Sprintf("https://%s%s", oc.ApiUrl, path)
+	req, err := http.NewRequest(http.MethodPut, requestUrl, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("error reading request: %w", err)
+	}
+
+	return oc.PerformRequest(req)
+}
+
+// make a delete request, expects a path
+func (oc *OpenshiftClient) DoOpenshiftDeleteRequest(path string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
+	}
+
+	return oc.PerformRequest(req)
+}
+
+// Common function for setting auth headers on request and performing the request
+func (oc *OpenshiftClient) PerformRequest(req *http.Request) (*http.Response, error) {
+	// Set auth headers from current user session
+	token, err := getOauthTokenFromCookie(oc.MasterUrl, oc.HTTPClient)
+	if err != nil {
+		return nil, fmt.Errorf("error getting the oauth token client: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	// Perform http request
+	resp, err := oc.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
+	}
+
+	return resp, nil
+}

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -1,0 +1,155 @@
+package resources
+
+import (
+	goctx "context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/headzoo/surf"
+	"github.com/headzoo/surf/browser"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	OpenshiftAuthenticationNamespace = "openshift-authentication"
+	OpenshiftOAuthRouteName          = "oauth-openshift"
+
+	PathProjectRequests = "/apis/project.openshift.io/v1/projectrequests"
+	PathProjects        = "/api/kubernetes/apis/apis/project.openshift.io/v1/projects"
+)
+
+// User used to create url user query
+type User struct {
+	Username string `url:"username"`
+	Password string `url:"password"`
+}
+
+// LoginOptions used to create and parse url login options
+type LoginOptions struct {
+	Client string `url:"client_id"`
+	IDP    string `url:"idp"`
+}
+
+// CallbackOptions used to create and parse url callback options
+type CallbackOptions struct {
+	Response string `url:"response_type"`
+	Scope    string `url:"scope"`
+	State    string `url:"state"`
+}
+
+// doAuthOpenshiftUser this function expects users and IDP to be created via `./scripts/setup-sso-idp.sh`
+func DoAuthOpenshiftUser(authPageURL string, username string, password string, httpClient *http.Client, idp string, l SimpleLogger) error {
+	parsedURL, err := url.Parse(authPageURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse url %s: %w", authPageURL, err)
+	}
+	if parsedURL.Scheme == "" {
+		authPageURL = fmt.Sprintf("https://%s", authPageURL)
+	}
+	l.Log("Performing OpenShift HTTP client setup with URL", authPageURL)
+
+	//follow the oauth proxy flow
+	browser := surf.NewBrowser()
+	browser.SetCookieJar(httpClient.Jar)
+	browser.SetTransport(httpClient.Transport)
+
+	if err := browser.Open(authPageURL); err != nil {
+		return fmt.Errorf("failed to open browser url: %w", err)
+	}
+
+	if err := OpenshiftClientSubmitForm(browser, username, password, idp, l); err != nil {
+		return fmt.Errorf("error occurred during oauth login: %w", err)
+	}
+	return nil
+}
+
+/*
+Checks if openshift user has been reconciled to the openshift realm in keycloak
+*/
+func OpenshiftUserReconcileCheck(openshiftClient *OpenshiftClient, k8sclient dynclient.Client, namespacePrefix, username string) error {
+	userSyncRetryInterval := time.Second * 30
+	userSyncTimeout := time.Minute * 5
+
+	return wait.Poll(userSyncRetryInterval, userSyncTimeout, func() (done bool, err error) {
+
+		fuseNamespace := fmt.Sprintf("%v%v", namespacePrefix, integreatlyv1alpha1.ProductFuse)
+		// ensure the fuse project can be seen by the user
+		if _, err := openshiftClient.GetProject(fuseNamespace); err != nil {
+			// fuse project not available to the user yet
+			if strings.Contains(err.Error(), "forbidden") {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get fuse project: %v", err)
+		}
+
+		// ensure that a generated keycloak user cr has been created for the user
+		generatedKeycloakUsers := &keycloak.KeycloakUserList{}
+		labelSelector, err := labels.Parse("sso=integreatly")
+		if err != nil {
+			return false, fmt.Errorf("failed to parse label selector: %v", err)
+		}
+		rhssoNamespace := fmt.Sprintf("%s%s", namespacePrefix, "rhsso")
+		if err := k8sclient.List(goctx.TODO(), generatedKeycloakUsers, &dynclient.ListOptions{LabelSelector: labelSelector, Namespace: rhssoNamespace}); err != nil {
+			return false, fmt.Errorf("failed to list keycloak users: %v", err)
+		}
+
+		for _, user := range generatedKeycloakUsers.Items {
+			if user.Spec.User.UserName == username {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+//openshiftOAuthProxyLogin Retrieve a cookie by logging in through the OpenShift OAuth Proxy
+func OpenshiftClientSubmitForm(browser *browser.Browser, username, password string, idp string, l SimpleLogger) error {
+	//oauth proxy-specific constants
+	const (
+		openshiftConsoleSubdomain = "oauth-openshift."
+	)
+
+	browser.Find("noscript").Each(func(i int, selection *goquery.Selection) {
+		selection.SetHtml(selection.Text())
+	})
+	if err := browser.Click(fmt.Sprintf("a:contains('%s')", idp)); err != nil {
+		l.Log("Error clicking IDP link")
+		return fmt.Errorf("failed to click testing-idp identity provider in oauth proxy login, ensure the identity provider exists on the cluster: %w", err)
+	}
+
+	loginForm, err := browser.Form("#kc-form-login")
+	if err != nil {
+		l.Log("Error filling in form #kc-form-login on page")
+		return fmt.Errorf("failed to get login form from oauth proxy screen: %w", err)
+	}
+	if err = loginForm.Input("username", username); err != nil {
+		return fmt.Errorf("failed to set username on oauth proxy form: %w", err)
+	}
+	if err = loginForm.Input("password", password); err != nil {
+		return fmt.Errorf("failed to set password on oauth proxy form: %w", err)
+	}
+	if err = loginForm.Submit(); err != nil {
+		return fmt.Errorf("failed to submit login form on oauth proxy screen: %w", err)
+	}
+	//sometimes we'll reach an accept permissions page for the user if they haven't accepted these scope requests before.
+	//refactored, this approach assumes that if the redirected page is not the console then it looks for an approve action, previous approach would cause e2e test flakes
+	if strings.Contains(browser.Url().Host, openshiftConsoleSubdomain) {
+		permissionsForm, err := browser.Form("[action=approve]")
+		if err != nil {
+			l.Log("Error looking for permissions form on page", browser.Url().Host, browser.Body())
+			return fmt.Errorf("failed to get permissions form: %w", err)
+		}
+		if err = permissionsForm.Submit(); err != nil {
+			return fmt.Errorf("failed to submit acceptance button for permissions: %w", err)
+		}
+	}
+	return nil
+}

--- a/test/resources/types.go
+++ b/test/resources/types.go
@@ -1,0 +1,5 @@
+package resources
+
+type SimpleLogger interface {
+	Log(...interface{})
+}


### PR DESCRIPTION
Migration of the e2e tests over to the operator-sdk 1.0.0+ the tests now uses testsenv and GinkGo. The tests are passing although we still need to complete some follow on tickets to finalize the migration of the tests.

https://issues.redhat.com/browse/MGDAPI-1038

**Verification steps**

- Install RHOAM/RHMI on a cluster 
- Once the install is completed run: `ginkgo -r test/e2e`